### PR TITLE
Improve GitHub panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ python3 -m http.server
 
 and visit `http://localhost:8000` in your browser. The site uses Bootstrap and Remix Icon CDN links, so an internet connection is required for full styling. The main page also includes basic SEO metadata for better discoverability.
 
+The GitHub panel includes a copy button with a prefilled `git clone` command so you can quickly grab the site's source.
+
 ## Purpose
 This repository hosts Benny's personal site and small experiments. The goal is to keep things simple and easily hackable.
 

--- a/github.html
+++ b/github.html
@@ -1,3 +1,8 @@
 <header>GitHub <button class="close-btn" aria-label="Close">&times;</button></header>
 <div class="progress-container"><div class="progress-bar" id="githubProgress"></div></div>
 <p id="githubText">Redirecting to GitHub in 3…</p>
+<p class="manual-link">If nothing happens, <a href="https://github.com/bennyhartnett/bennyhartnett.com" target="_blank" rel="noopener" id="githubLink">open the repository</a>.</p>
+<div class="input-group mb-3">
+  <input type="text" class="form-control" id="gitCloneInput" value="git clone https://github.com/bennyhartnett/bennyhartnett.com" readonly>
+  <button class="btn btn-outline-secondary" id="cloneCopyBtn" type="button">Copy</button>
+</div>

--- a/script.js
+++ b/script.js
@@ -42,6 +42,11 @@
           navigator.clipboard.writeText(panel.querySelector('#emailInput').value);
         });
       }
+      if (id === 'github') {
+        panel.querySelector('#cloneCopyBtn').addEventListener('click', () => {
+          navigator.clipboard.writeText(panel.querySelector('#gitCloneInput').value);
+        });
+      }
       if (id === 'search') {
         const input = panel.querySelector('input');
         const resultsEl = panel.querySelector('.search-results');
@@ -127,7 +132,7 @@
 
     function showPanel(id) {
       loadPanelContent(id);
-      if (id === 'github') startRedirect('https://github.com/bennyhartnett', 'githubText', 'githubProgress', 'GitHub');
+      if (id === 'github') startRedirect('https://github.com/bennyhartnett/bennyhartnett.com', 'githubText', 'githubProgress', 'GitHub');
       if (id === 'linkedin') startRedirect('https://www.linkedin.com/in/dev-dc/', 'linkedinText', 'linkedinProgress', 'LinkedIn');
       iconGrid.classList.add('hidden');
       panels.forEach(p => p.classList.toggle('open', p.id === id));

--- a/style.css
+++ b/style.css
@@ -243,3 +243,13 @@
 .panel::-webkit-scrollbar-thumb:hover { background: rgba(52,121,255,0.8); }
 .panel { scrollbar-width: thin; scrollbar-color: rgba(52,121,255,0.6) rgba(0,0,0,0.1); }
 
+/* GitHub panel extras */
+.manual-link {
+  text-align: center;
+  margin-bottom: 0.75rem;
+}
+
+#github .input-group {
+  margin-bottom: 0.75rem;
+}
+


### PR DESCRIPTION
## Summary
- add manual repository link and clone command to `github.html`
- let users copy the clone command from the GitHub panel
- point GitHub redirect to this repository
- style new GitHub panel elements
- document GitHub panel clone button in README

## Testing
- `true`