### PR TITLE
Enable hover scroll and hide scrollbars

### DIFF
--- a/script.js
+++ b/script.js
@@ -1,3 +1,28 @@
+    /* GLOBAL HOVER SCROLL */
+    function enableHoverScroll(target, edge = 20, speed = 6) {
+      let interval;
+      const el = target === window ? document.documentElement : target;
+      const move = e => {
+        const rect = target === window ? {top:0,bottom:window.innerHeight} : el.getBoundingClientRect();
+        if (e.clientY > rect.bottom - edge) {
+          clearInterval(interval);
+          interval = setInterval(() => {
+            target === window ? window.scrollBy(0, speed) : (el.scrollTop += speed);
+          }, 16);
+        } else if (e.clientY < rect.top + edge) {
+          clearInterval(interval);
+          interval = setInterval(() => {
+            target === window ? window.scrollBy(0, -speed) : (el.scrollTop -= speed);
+          }, 16);
+        } else {
+          clearInterval(interval);
+        }
+      };
+      el.addEventListener('mousemove', move);
+      el.addEventListener('mouseleave', () => clearInterval(interval));
+    }
+    enableHoverScroll(window);
+
     /* INTERACTIVITY */
     const iconGrid = document.getElementById('iconGrid');
     const icons = document.querySelectorAll('.icon-btn');
@@ -86,25 +111,7 @@
         input.addEventListener('input', renderResults);
         panel.querySelector('#searchBtn').addEventListener('click', renderResults);
 
-        let hoverInterval;
-        resultsEl.addEventListener('mousemove', e => {
-          const rect = resultsEl.getBoundingClientRect();
-          const speed = 4;
-          if (e.clientY > rect.bottom - 20) {
-            clearInterval(hoverInterval);
-            hoverInterval = setInterval(() => {
-              resultsEl.scrollTop += speed;
-            }, 16);
-          } else if (e.clientY < rect.top + 20) {
-            clearInterval(hoverInterval);
-            hoverInterval = setInterval(() => {
-              resultsEl.scrollTop -= speed;
-            }, 16);
-          } else {
-            clearInterval(hoverInterval);
-          }
-        });
-        resultsEl.addEventListener('mouseleave', () => clearInterval(hoverInterval));
+        enableHoverScroll(resultsEl);
 
         renderResults();
       }
@@ -131,6 +138,7 @@
           mapEl.textContent = 'Map failed to load';
         }
       }
+      enableHoverScroll(panel);
       panel.dataset.init = 'true';
     }
 

--- a/style.css
+++ b/style.css
@@ -236,16 +236,16 @@
   to { opacity: 1; transform: translateY(0); }
 }
 
-/* Rounded scrollbars for panels */
-.panel::-webkit-scrollbar { width: 8px; height: 8px; }
-.panel::-webkit-scrollbar-track {
-  background: rgba(0,0,0,0.1);
-  border-radius: 10px;
-  margin: 10px 0; /* keep scrollbar 10px from top and bottom */
+/* Hide native scrollbars */
+body, html, .panel {
+  scrollbar-width: none;
+  -ms-overflow-style: none;
 }
-.panel::-webkit-scrollbar-thumb { background: rgba(52,121,255,0.6); border-radius: 10px; }
-.panel::-webkit-scrollbar-thumb:hover { background: rgba(52,121,255,0.8); }
-.panel { scrollbar-width: thin; scrollbar-color: rgba(52,121,255,0.6) rgba(0,0,0,0.1); }
+body::-webkit-scrollbar,
+html::-webkit-scrollbar,
+.panel::-webkit-scrollbar {
+  display: none;
+}
 
 /* GitHub panel extras */
 .manual-link {


### PR DESCRIPTION
## Summary
- hide all scrollbars via CSS
- add generic `enableHoverScroll` helper and apply to page
- use helper for search results and panels

## Testing
- `npm test` *(fails: cannot find package.json)*