### PR TITLE
Update GIS icon to link directly

### DIFF
--- a/script.js
+++ b/script.js
@@ -147,7 +147,14 @@
       iconGrid.classList.remove('hidden');
     }
 
-    icons.forEach(icon => icon.addEventListener('click', () => showPanel(icon.dataset.panel)));
+    icons.forEach(icon => icon.addEventListener('click', () => {
+      const panel = icon.dataset.panel;
+      if (panel === 'gis') {
+        window.location.href = 'gis.html';
+        return;
+      }
+      showPanel(panel);
+    }));
 
     /* REDIRECT COUNTDOWN WITH PROGRESS */
     function startRedirect(url, textId, progressId, name) {


### PR DESCRIPTION
## Summary
- add click handler to redirect GIS icon to `gis.html`

## Testing
- `python3 -m http.server` *(fails: terminated)*