### PR TITLE
Add dark search modal to GIS page

### DIFF
--- a/gis.html
+++ b/gis.html
@@ -38,10 +38,66 @@
       height: 14px;
       margin-right: 4px;
     }
+
+    /* Simple dark modal */
+    .modal {
+      position: fixed;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+      background: rgba(0, 0, 0, 0.85);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      color: #fff;
+      z-index: 1000;
+    }
+    .modal-content {
+      background: #222;
+      padding: 1.5rem;
+      border-radius: 8px;
+      width: 90%;
+      max-width: 500px;
+      box-shadow: 0 4px 20px rgba(0,0,0,0.5);
+    }
+    .modal textarea,
+    .modal input {
+      width: 100%;
+      background: #333;
+      color: #fff;
+      border: 1px solid #555;
+      border-radius: 4px;
+      padding: 0.5rem;
+      margin-bottom: 1rem;
+    }
+    .modal textarea {
+      height: 120px;
+      resize: vertical;
+    }
+    .modal button {
+      width: 100%;
+      background: #007bff;
+      color: #fff;
+      border: none;
+      padding: 0.5rem 1rem;
+      border-radius: 4px;
+      cursor: pointer;
+    }
+    .modal button:hover {
+      background: #0069d9;
+    }
   </style>
 </head>
 <body>
   <div id="map"></div>
+  <div class="modal" id="searchModal">
+    <div class="modal-content">
+      <textarea placeholder="Describe what you are searching for."></textarea>
+      <input type="text" placeholder="Near Location:">
+      <button id="findBtn">Find</button>
+    </div>
+  </div>
 
   <!-- Leaflet JS -->
   <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
@@ -69,6 +125,11 @@
     map.locate({ setView: true, maxZoom: 16 });
     map.on('locationfound', function(e) {
       L.marker(e.latlng).addTo(map);
+    });
+
+    // Hide modal when Find button is clicked
+    document.getElementById('findBtn').addEventListener('click', function() {
+      document.getElementById('searchModal').style.display = 'none';
     });
   </script>
 </body>


### PR DESCRIPTION
## Summary
- add dark theme modal overlay to `gis.html`
- include basic styling for textarea, location input, and Find button
- hide modal when Find is clicked

## Testing
- `git status --short`