### PR TITLE
Center home page links

### DIFF
--- a/home.html
+++ b/home.html
@@ -8,6 +8,13 @@
     body {
       font-family: 'Inter', sans-serif;
       color: white;
+      margin: 0;
+    }
+    .home-container {
+      min-height: calc(100vh - 56px);
+      display: flex;
+      justify-content: center;
+      align-items: center;
       padding: 1rem;
     }
     .link-list {
@@ -17,6 +24,7 @@
       display: flex;
       flex-wrap: wrap;
       gap: 1rem;
+      justify-content: center;
     }
     .link-list li {
       margin: 0;
@@ -32,6 +40,7 @@
   </style>
 </head>
 <body>
+  <div class="home-container">
   <ul class="link-list">
     <li><a href="https://www.linkedin.com/in/benny-hartnett" target="_blank">LinkedIn</a></li>
     <li><a href="mailto:benny@example.com">Email</a></li>
@@ -39,6 +48,7 @@
     <li><a href="gis.html">GIS</a></li>
     <li><a href="nuclear.html">Nuclear</a></li>
     <li><a href="https://github.com">GitHub</a></li>
-  </ul>
+</ul>
+  </div>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -255,10 +255,12 @@
           // Fallback content when running directly from the file system
           container.innerHTML = `\
               <style>\
-                .link-list { list-style: none; padding: 0; margin: 0; display: flex; flex-wrap: wrap; gap: 1rem; }\
+                .home-container { min-height: calc(100vh - 56px); display: flex; justify-content: center; align-items: center; padding: 1rem; }\
+                .link-list { list-style: none; padding: 0; margin: 0; display: flex; flex-wrap: wrap; gap: 1rem; justify-content: center; }\
                 .link-list li { margin: 0; }\
                 .link-list a { display: block; color: white; text-decoration: none; font-size: 1.5rem; font-family: 'Inter', sans-serif; padding: 0.5rem; }\
               </style>\
+              <div class="home-container">\
               <ul class="link-list">\
               <li><a href="https://www.linkedin.com/in/benny-hartnett" target="_blank">LinkedIn</a></li>\
               <li><a href="mailto:benny@example.com">Email</a></li>\
@@ -266,7 +268,8 @@
               <li><a href="gis.html">GIS</a></li>\
               <li><a href="nuclear.html">Nuclear</a></li>\
               <li><a href="https://github.com">GitHub</a></li>\
-            </ul>`;
+            </ul>\
+            </div>`;
         });
     });
   </script>


### PR DESCRIPTION
## Summary
- center home page links horizontally and vertically
- update fallback markup so direct index.html loads show centered links

## Testing
- `git diff --cached --name-status`

------
https://chatgpt.com/codex/tasks/task_b_68422ead13d48333b439f9d34a7b3164