### PR TITLE
Increase spacing for homepage links

### DIFF
--- a/home.html
+++ b/home.html
@@ -23,7 +23,7 @@
       margin: 0;
       display: flex;
       flex-wrap: wrap;
-      gap: 1rem;
+      gap: 1.5rem;
       justify-content: center;
     }
     .link-list li {
@@ -35,7 +35,7 @@
       text-decoration: none;
       font-size: 1.5rem;
       font-family: inherit;
-      padding: 0.5rem;
+      padding: 0.75rem;
     }
   </style>
 </head>

--- a/index.html
+++ b/index.html
@@ -49,7 +49,7 @@
     nav .menu {
       display: flex;
       flex-wrap: wrap;
-      gap: 6px;
+      gap: 12px;
       flex: 1 1 auto;
       justify-content: flex-end;
     }
@@ -60,7 +60,7 @@
       text-decoration: none;
       font-size: 0.95em;
       white-space: nowrap;
-      padding: 3px 5px;
+      padding: 4px 8px;
     }
     /* Stack title and menu vertically on narrower screens */
     @media (max-width: 700px) {
@@ -256,9 +256,9 @@
           container.innerHTML = `\
               <style>\
                 .home-container { min-height: calc(100vh - 56px); display: flex; justify-content: center; align-items: center; padding: 1rem; }\
-                .link-list { list-style: none; padding: 0; margin: 0; display: flex; flex-wrap: wrap; gap: 1rem; justify-content: center; }\
+                .link-list { list-style: none; padding: 0; margin: 0; display: flex; flex-wrap: wrap; gap: 1.5rem; justify-content: center; }\
                 .link-list li { margin: 0; }\
-                .link-list a { display: block; color: white; text-decoration: none; font-size: 1.5rem; font-family: 'Inter', sans-serif; padding: 0.5rem; }\
+                .link-list a { display: block; color: white; text-decoration: none; font-size: 1.5rem; font-family: 'Inter', sans-serif; padding: 0.75rem; }\
               </style>\
               <div class="home-container">\
               <ul class="link-list">\


### PR DESCRIPTION
## Summary
- widen link spacing on the home page
- adjust fallback styles in index.html
- add more padding and gap for top navigation links

## Testing
- `tidy -e index.html`
- `tidy -e home.html`

------
https://chatgpt.com/codex/tasks/task_b_6842300d36fc8333a93a756ff3769500