### PR TITLE
Fix homepage scroll

### DIFF
--- a/home.html
+++ b/home.html
@@ -11,7 +11,7 @@
       margin: 0;
     }
     .home-container {
-      min-height: calc(100vh - 56px);
+      min-height: calc(100vh - 56px - 2rem);
       display: flex;
       justify-content: center;
       align-items: center;

--- a/index.html
+++ b/index.html
@@ -95,7 +95,7 @@
     /* Provide spacing at top so content isn't covered by nav */
     .content {
       margin-top: 56px; /* approx nav height */
-      padding: 1rem;
+      padding: 0 1rem; /* only horizontal padding to avoid extra height */
       font-family: 'Inter', sans-serif;
       color: white;
     }
@@ -255,7 +255,7 @@
           // Fallback content when running directly from the file system
           container.innerHTML = `\
               <style>\
-                .home-container { min-height: calc(100vh - 56px); display: flex; justify-content: center; align-items: center; padding: 1rem; }\
+                .home-container { min-height: calc(100vh - 56px - 2rem); display: flex; justify-content: center; align-items: center; padding: 1rem; }\
                 .link-list { list-style: none; padding: 0; margin: 0; display: flex; flex-wrap: wrap; gap: 1.5rem; justify-content: center; }\
                 .link-list li { margin: 0; }\
                 .link-list a { display: block; color: white; text-decoration: none; font-size: 1.5rem; font-family: 'Inter', sans-serif; padding: 0.75rem; }\


### PR DESCRIPTION
## Summary
- avoid unnecessary vertical padding around content
- adjust home container size to account for its padding

## Testing
- `npm --version`

------
https://chatgpt.com/codex/tasks/task_b_684231b8f7ec8333a1c08a2bb01257b1