### PR TITLE
Update canonical domain to match live site

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ python3 -m http.server
 
 Navigate to `http://localhost:8000` to view the pages. Because scripts are pulled from CDNs, no installation is required.
 
+You can also view a live deployment at [bennyhartnett.com](https://bennyhartnett.com).
+
 ## Customization
 
 - **Navigation links** &ndash; Edit the `<nav>` element in `index.html` to change the menu structure or link targets.

--- a/index.html
+++ b/index.html
@@ -8,11 +8,11 @@
   <meta name="description" content="Insights and projects spanning generative AI, GIS, government contracting, and nuclear research." />
   <meta name="keywords" content="Benny Hartnett, generative AI, GIS, government contracting, nuclear" />
   <meta name="author" content="Benny Hartnett" />
-  <link rel="canonical" href="https://federalinnovations.example.com/" />
+  <link rel="canonical" href="https://bennyhartnett.com/" />
   <meta property="og:title" content="Federal Innovations - Benny Hartnett" />
   <meta property="og:description" content="Explore projects and articles on generative AI, GIS, government contracting, and nuclear technology." />
   <meta property="og:type" content="website" />
-  <meta property="og:url" content="https://federalinnovations.example.com/" />
+  <meta property="og:url" content="https://bennyhartnett.com/" />
  
   <script async src="https://ga.jspm.io/npm:es-module-shims@1.5.1/dist/es-module-shims.js" crossorigin="anonymous"></script>
   <script type="importmap">


### PR DESCRIPTION
## Summary
- update canonical and og:url meta tags to point to `bennyhartnett.com`
- mention live deployment URL in the README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_68424687b434833399fb1c1f4e6cd329