### PR TITLE
Update branding and contact info

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# FederalInnovations
+# bennyhartnett.com
 
 This project contains a collection of static HTML pages that serve as a lightweight personal and professional site. The landing page relies on [three.js](https://threejs.org/) to render a dynamic wave animation in the background. All files can be opened directly in a browser with no build step required.
 
@@ -49,7 +49,7 @@ The pages load the following libraries from public CDNs:
 
 - GitHub: [bennyhartnett](https://github.com/bennyhartnett)
 - LinkedIn: [dev-dc](https://www.linkedin.com/in/dev-dc)
-- Email: [benny@example.com](mailto:benny@example.com)
+- Email: [me@bennyhartnett.com](mailto:me@bennyhartnett.com)
 
 ## License
 

--- a/home.html
+++ b/home.html
@@ -40,7 +40,7 @@
 </style>
 <div class="home-container">
 <ul class="link-list">
-  <li><a href="mailto:benny@example.com">Email</a></li>
+  <li><a href="mailto:me@bennyhartnett.com">Email</a></li>
   <li><a href="https://www.lionpro.ai/" target="_blank" rel="noopener">Generative AI</a></li>
   <li><a href="gis.html">GIS</a></li>
       <li><a href="https://github.com/bennyhartnett" target="_blank" rel="noopener">GitHub</a></li>

--- a/index.html
+++ b/index.html
@@ -5,17 +5,17 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
-  <title>Federal Innovations - Benny Hartnett</title>
+  <title>Benny Hartnett</title>
   <meta name="description"
     content="Insights and projects spanning generative AI, GIS, government contracting, and nuclear research." />
   <meta name="keywords" content="Benny Hartnett, generative AI, GIS, government contracting, nuclear" />
   <meta name="author" content="Benny Hartnett" />
-  <link rel="canonical" href="https://federalinnovations.example.com/" />
-  <meta property="og:title" content="Federal Innovations - Benny Hartnett" />
+  <link rel="canonical" href="https://bennyhartnett.com/" />
+  <meta property="og:title" content="Benny Hartnett" />
   <meta property="og:description"
     content="Explore projects and articles on generative AI, GIS, government contracting, and nuclear technology." />
   <meta property="og:type" content="website" />
-  <meta property="og:url" content="https://federalinnovations.example.com/" />
+  <meta property="og:url" content="https://bennyhartnett.com/" />
 
   <script async src="https://ga.jspm.io/npm:es-module-shims@1.5.1/dist/es-module-shims.js"
     crossorigin="anonymous"></script>
@@ -323,7 +323,7 @@
                 <div class="home-container">\
                 <ul class="link-list">\
                   <li><a href="https://www.linkedin.com/in/dev-dc" target="_blank" rel="noopener">LinkedIn</a></li>\
-                <li><a href="mailto:benny@example.com">Email</a></li>\
+                <li><a href="mailto:me@bennyhartnett.com">Email</a></li>\
                   
                 
                 <li><a href="https://github.com/bennyhartnett" target="_blank" rel="noopener">GitHub</a></li>\

--- a/privacy.html
+++ b/privacy.html
@@ -20,7 +20,7 @@
 
   <p>
     This page explains how we handle any information collected through
-    <strong>Federal Innovations</strong>. The site is static and does not
+    <strong>bennyhartnett.com</strong>. The site is static and does not
     actively gather personal data.
   </p>
 
@@ -28,7 +28,7 @@
   <ul>
     <li>
       <strong>Email communications:</strong> If you contact us at
-      <a href="mailto:benny@example.com">benny@example.com</a>, we will use the
+      <a href="mailto:me@bennyhartnett.com">me@bennyhartnett.com</a>, we will use the
       details you provide solely to respond to your request.
     </li>
     <li>
@@ -51,7 +51,7 @@
   <h2>Your Rights and Choices</h2>
   <p>
     You may request that we update or delete your personal information at any
-    time by emailing <a href="mailto:benny@example.com">benny@example.com</a>.
+    time by emailing <a href="mailto:me@bennyhartnett.com">me@bennyhartnett.com</a>.
     We will honor such requests unless we are legally required to keep the
     information.
   </p>
@@ -80,14 +80,14 @@
   <p>
     This policy is provided for general information only and does not create any
     warranties or legal obligations. By using this site, you agree that
-    <strong>Federal Innovations</strong> and its administrators are not
+    <strong>bennyhartnett.com</strong> and its administrators are not
     responsible for any damages or losses resulting from your use of the site or
     from reliance on the information presented here.
   </p>
 
   <p>
     For questions about this policy, contact us at
-    <a href="mailto:benny@example.com">benny@example.com</a>.
+    <a href="mailto:me@bennyhartnett.com">me@bennyhartnett.com</a>.
   </p>
 
   <a href="index.html">Back to Home</a>


### PR DESCRIPTION
## Summary
- update site name and canonical URL to bennyhartnett.com
- update email address across pages
- replace old brand references in the privacy policy

## Testing
- `grep -R "benny@example.com" -n`


------
https://chatgpt.com/codex/tasks/task_b_68424ab3437c83339a945c45f729f597