### PR TITLE
Add Concepts page and link

### DIFF
--- a/concepts.html
+++ b/concepts.html
@@ -1,0 +1,18 @@
+<style>
+  @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap');
+  body {
+    font-family: 'Inter', sans-serif;
+    color: white;
+    padding: 1rem;
+  }
+  a {
+    color: white;
+    transition: color 0.3s ease;
+  }
+
+  a:hover {
+    color: var(--wave-color);
+  }
+</style>
+<h1>Concepts</h1>
+<p>This page will outline various concepts and ideas explored on this site.</p>

--- a/home.html
+++ b/home.html
@@ -59,7 +59,8 @@
   <li><a href="gis.html">GIS</a></li>
       <li><a href="https://github.com/bennyhartnett" target="_blank" rel="noopener">GitHub</a></li>
       <li><a href="https://lionfederal.com" target="_blank" rel="noopener">Government Contracting</a></li>
-      <li><a href="https://www.linkedin.com/in/dev-dc" target="_blank" rel="noopener">LinkedIn</a></li>
-    <li><a href="https://bennyhartnett.com/experiments.html" target="_blank" rel="noopener">Nuclear</a></li>
+  <li><a href="https://www.linkedin.com/in/dev-dc" target="_blank" rel="noopener">LinkedIn</a></li>
+  <li><a href="https://bennyhartnett.com/experiments.html" target="_blank" rel="noopener">Nuclear</a></li>
+  <li><a href="concepts.html">Concepts</a></li>
 </ul>
   </div>

--- a/index.html
+++ b/index.html
@@ -389,6 +389,10 @@
           title: 'Nuclear Research - Benny Hartnett',
           desc: 'Summaries of Benny Hartnett\'s nuclear-related projects.'
         },
+        'concepts.html': {
+          title: 'Concepts - Benny Hartnett',
+          desc: 'High-level concepts and ideas explored on this site.'
+        },
         'privacy.html': {
           title: 'Privacy Policy - Benny Hartnett',
           desc: 'Privacy practices for bennyhartnett.com.'

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -19,6 +19,9 @@
     <loc>https://bennyhartnett.com/nuclear.html</loc>
   </url>
   <url>
+    <loc>https://bennyhartnett.com/concepts.html</loc>
+  </url>
+  <url>
     <loc>https://bennyhartnett.com/privacy.html</loc>
   </url>
 </urlset>


### PR DESCRIPTION
## Summary
- add concepts link on home page and sitemap
- include metadata for concepts page in `index.html`
- create new `concepts.html` page with placeholder text

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_b_68426c95aa088333beeaf338c1a9a8de