### PR TITLE
Implement email copy-to-clipboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ The pages load the following libraries from public CDNs:
 
 - GitHub: [bennyhartnett](https://github.com/bennyhartnett)
 - LinkedIn: [dev-dc](https://www.linkedin.com/in/dev-dc)
-- Email: [me@bennyhartnett.com](mailto:me@bennyhartnett.com)
+- Email: me@bennyhartnett.com
 
 ## License
 

--- a/home.html
+++ b/home.html
@@ -54,7 +54,7 @@
 </style>
 <div class="home-container">
 <ul class="link-list">
-  <li><a href="mailto:me@bennyhartnett.com">Email</a></li>
+  <li><a href="#" class="copy-email" data-email="me@bennyhartnett.com">Email</a></li>
   <li><a href="https://www.lionpro.ai/" target="_blank" rel="noopener">Generative AI</a></li>
   <li><a href="gis.html">GIS</a></li>
       <li><a href="https://github.com/bennyhartnett" target="_blank" rel="noopener">GitHub</a></li>

--- a/index.html
+++ b/index.html
@@ -441,7 +441,7 @@
                 <div class="home-container">\
                 <ul class="link-list">\
                   <li><a href="https://www.linkedin.com/in/dev-dc" target="_blank" rel="noopener">LinkedIn</a></li>\
-                <li><a href="mailto:me@bennyhartnett.com">Email</a></li>\
+                  <li><a href="#" class="copy-email" data-email="me@bennyhartnett.com">Email</a></li>\
                   
                 
                 <li><a href="https://github.com/bennyhartnett" target="_blank" rel="noopener">GitHub</a></li>\
@@ -482,6 +482,15 @@
       }
 
       document.body.addEventListener('click', (e) => {
+        const emailLink = e.target.closest('.copy-email');
+        if (emailLink) {
+          e.preventDefault();
+          const email = emailLink.dataset.email;
+          navigator.clipboard.writeText(email).then(() => {
+            alert('Email copied to clipboard');
+          });
+          return;
+        }
         const link = e.target.closest('a');
         if (!link) return;
         const href = link.getAttribute('href');

--- a/privacy.html
+++ b/privacy.html
@@ -29,7 +29,7 @@
   <ul>
     <li>
       <strong>Email communications:</strong> If you contact us at
-      <a href="mailto:me@bennyhartnett.com">me@bennyhartnett.com</a>, we will use the
+      <a href="#" class="copy-email" data-email="me@bennyhartnett.com">me@bennyhartnett.com</a>, we will use the
       details you provide solely to respond to your request.
     </li>
     <li>
@@ -65,7 +65,7 @@
   <h2>Your Rights and Choices</h2>
   <p>
     You may request that we update or delete your personal information at any
-    time by emailing <a href="mailto:me@bennyhartnett.com">me@bennyhartnett.com</a>.
+    time by emailing <a href="#" class="copy-email" data-email="me@bennyhartnett.com">me@bennyhartnett.com</a>.
     We will honor such requests unless we are legally required to keep the
     information.
   </p>
@@ -101,7 +101,7 @@
 
   <p>
     For questions about this policy, contact us at
-    <a href="mailto:me@bennyhartnett.com">me@bennyhartnett.com</a>.
+    <a href="#" class="copy-email" data-email="me@bennyhartnett.com">me@bennyhartnett.com</a>.
   </p>
 
   <p>


### PR DESCRIPTION
## Summary
- replace all `mailto:` links with buttons that copy the email address to the user's clipboard
- support copy behaviour via JavaScript handler
- update README contact info accordingly

## Testing
- `grep -nri "mailto" -n`

------
https://chatgpt.com/codex/tasks/task_b_686c769f28a48333b6ab901162312f07