### PR TITLE
Add Pages deployment and Prettier CI

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,22 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@v3
+      - name: Upload pages artifact
+        uses: actions/upload-pages-artifact@v1
+        with:
+          path: ./
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v1

--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -1,0 +1,17 @@
+name: Prettier Check
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  prettier:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+      - name: Run Prettier
+        run: npx prettier --check .

--- a/README.md
+++ b/README.md
@@ -44,6 +44,11 @@ Open `http://localhost:8000` in your browser. Because all scripts load from CDNs
 
 The site is entirely static, so you can host it anywhere that serves HTML files. Copy the repository contents to your preferred platform&mdash;GitHub Pages, an S3 bucket, Netlify, and so on&mdash;and it will work without additional configuration.
 
+## Continuous Integration
+
+- `deploy.yml` publishes the `main` branch to GitHub Pages using GitHub Actions.
+- `prettier.yml` runs Prettier to check HTML, CSS, and JavaScript formatting on pushes and pull requests.
+
 ## Dependencies
 
 The pages load the following libraries from public CDNs:


### PR DESCRIPTION
## Summary
- automatically deploy `main` to GitHub Pages
- check HTML/CSS/JS formatting with Prettier
- document the new workflows in the README

## Testing
- `npx prettier --check .` *(fails: code style issues found)*

------
https://chatgpt.com/codex/tasks/task_b_686c79c61f948333bfc54519b142c25c