### PR TITLE
Enable GitHub Pages deployment

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,0 +1,34 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: ["main"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+      - name: Upload site
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: '.'
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/404.html
+++ b/404.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="refresh" content="0; url=index.html">
+  <title>Page Not Found</title>
+</head>
+<body>
+  <p>If you are not redirected, <a href="index.html">click here</a>.</p>
+</body>
+</html>

--- a/README.md
+++ b/README.md
@@ -44,6 +44,14 @@ Open `http://localhost:8000` in your browser. Because all scripts load from CDNs
 
 The site is entirely static, so you can host it anywhere that serves HTML files. Copy the repository contents to your preferred platform&mdash;GitHub Pages, an S3 bucket, Netlify, and so on&mdash;and it will work without additional configuration.
 
+### GitHub Pages
+
+1. Ensure the `gh-pages.yml` workflow is enabled in the repository's **Actions** tab.
+2. In the repository **Settings** &rarr; **Pages**, choose **GitHub Actions** as the source.
+3. Push changes to the `main` branch and the workflow will automatically deploy the site.
+
+The repository includes a `.nojekyll` file so Pages serves the files as-is.
+
 ## Dependencies
 
 The pages load the following libraries from public CDNs:

--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
     content="Insights and projects spanning generative AI, GIS, government contracting, and nuclear research." />
   <meta name="keywords" content="Benny Hartnett, generative AI, GIS, government contracting, nuclear" />
   <meta name="author" content="Benny Hartnett" />
-  <link rel="canonical" href="https://bennyhartnett.com/" />
+  <link rel="canonical" href="" id="canonical-link" />
   <link rel="sitemap" type="application/xml" href="sitemap.xml" />
   <link rel="icon" type="image/svg+xml" href="https://unpkg.com/heroicons@2.0.18/24/solid/code-bracket.svg" />
   <meta name="robots" content="index,follow" />
@@ -18,7 +18,7 @@
   <meta property="og:description"
     content="Explore projects and articles on generative AI, GIS, government contracting, and nuclear technology." />
   <meta property="og:type" content="website" />
-  <meta property="og:url" content="https://bennyhartnett.com/" />
+  <meta property="og:url" content="" id="og-url" />
 
   <script async src="https://ga.jspm.io/npm:es-module-shims@1.5.1/dist/es-module-shims.js"
     crossorigin="anonymous"></script>
@@ -376,6 +376,11 @@
       const container = document.querySelector('.content');
       const toggleBtn = document.querySelector('.menu-toggle');
       const menu = document.querySelector('nav .menu');
+      const canonicalTag = document.getElementById('canonical-link');
+      const ogUrlTag = document.getElementById('og-url');
+      const baseUrl = window.location.origin + window.location.pathname.replace(/[^\/]*$/, '');
+      if (canonicalTag) canonicalTag.setAttribute('href', baseUrl);
+      if (ogUrlTag) ogUrlTag.setAttribute('content', baseUrl);
       const metaMap = {
         'home.html': {
           title: 'Benny Hartnett - Home',
@@ -400,7 +405,7 @@
         },
         'privacy.html': {
           title: 'Privacy Policy - Benny Hartnett',
-          desc: 'Privacy practices for bennyhartnett.com.'
+          desc: 'Privacy practices for this site.'
         }
       };
       if (toggleBtn && menu) {
@@ -426,13 +431,14 @@
             const descTag = document.querySelector('meta[name="description"]');
             if (descTag) descTag.setAttribute('content', meta.desc);
             const canonical = document.querySelector('link[rel="canonical"]');
-            if (canonical) canonical.setAttribute('href', 'https://bennyhartnett.com/' + (url === 'home.html' ? '' : url));
+            const ogUrl = document.querySelector('meta[property="og:url"]');
+            const fullUrl = baseUrl + (url === 'home.html' ? '' : url);
+            if (canonical) canonical.setAttribute('href', fullUrl);
             const ogTitle = document.querySelector('meta[property="og:title"]');
             if (ogTitle) ogTitle.setAttribute('content', meta.title);
             const ogDesc = document.querySelector('meta[property="og:description"]');
             if (ogDesc) ogDesc.setAttribute('content', meta.desc);
-            const ogUrl = document.querySelector('meta[property="og:url"]');
-            if (ogUrl) ogUrl.setAttribute('content', 'https://bennyhartnett.com/' + (url === 'home.html' ? '' : url));
+            if (ogUrl) ogUrl.setAttribute('content', fullUrl);
             if (push) {
               history.pushState({ url }, '', '#' + url);
             }


### PR DESCRIPTION
## Summary
- update meta tags to support dynamic host
- add GitHub Pages workflow
- document Pages usage in README
- disable Jekyll and provide fallback 404 page

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_686c7fb75e1c83338defe25892575a50