### PR TITLE
Fix footer background color on scroll

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,15 +39,16 @@
       --wave-color: blue;
     }
 
-    html,
-    body {
-      width: 100%;
-      height: 100%;
-      margin: 0;
-      overflow-x: hidden;
-      /* allow vertical scrolling if needed */
-      overflow-y: auto;
-    }
+      html,
+      body {
+        width: 100%;
+        height: 100%;
+        margin: 0;
+        background: black;
+        overflow-x: hidden;
+        /* allow vertical scrolling if needed */
+        overflow-y: auto;
+      }
 
     /* Dark mode scrollbar */
     ::-webkit-scrollbar {


### PR DESCRIPTION
## Summary
- make the page background black so the footer stays dark even when scrolled beyond the wave canvas

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_686c906c3fbc833382f07f4739f84bd2