### PR TITLE
Debug nuclear button redirect issue

### DIFF
--- a/index.html
+++ b/index.html
@@ -509,7 +509,7 @@
                  <li><a href="https://www.lionpro.ai/" target="_blank" rel="noopener">Generative AI</a></li>\
                 <li><a href="https://lionfederal.com" target="_blank" rel="noopener">Government Contracting</a></li>\
                 
-                  <li><a href="https://bennyhartnett.com/experiments.html" target="_blank" rel="noopener">Nuclear</a></li>\
+                  <li><a href="nuclear.html">Nuclear</a></li>\
               </ul>\
               </div>`;
             } else if (url === 'gis.html') {


### PR DESCRIPTION
The Nuclear link in the home fallback content was incorrectly redirecting to experiments.html instead of nuclear.html.