### PR TITLE
Fix Centrus logo not displaying

### DIFF
--- a/nuclear.html
+++ b/nuclear.html
@@ -17,7 +17,7 @@
     <!-- Header -->
     <header class="mb-6 flex flex-col items-center gap-3">
       <img
-        src="https://bennyhartnett.com/assets/Centrus-Logo-Color-1-400x222.png"
+        src="https://www.centrusenergy.com/wp-content/themes/centrus/assets/img/logo-light-bg.png"
         alt="Centrus Energy logo"
         class="h-16 w-auto object-contain"
       />


### PR DESCRIPTION
The previous logo URL pointed to a non-existent asset on bennyhartnett.com. Updated to use the official Centrus Energy website logo.