### PR TITLE
Fix nuclear button requiring page refresh

### DIFF
--- a/nuclear.html
+++ b/nuclear.html
@@ -1262,7 +1262,8 @@
       if (document.readyState === "loading") {
         document.addEventListener("DOMContentLoaded", setupHandlers);
       } else {
-        setupHandlers();
+        // Use setTimeout to defer execution, ensuring DOM is ready after SPA navigation
+        setTimeout(setupHandlers, 0);
       }
     })();
   </script>


### PR DESCRIPTION
Use setTimeout to defer setupHandlers() execution when the document is already loaded (SPA navigation case). This ensures DOM elements are fully queryable after being inserted via innerHTML.