### PR TITLE
Add home icon to nuclear page

### DIFF
--- a/nuclear.html
+++ b/nuclear.html
@@ -29,6 +29,18 @@
   <main class="relative mx-auto w-full max-w-4xl rounded-2xl bg-white/95 dark:bg-slate-800/95 p-6 shadow-xl ring-1 ring-slate-200 dark:ring-slate-700 transition-colors duration-300">
     <!-- Header -->
     <header class="mb-6 flex flex-col items-center gap-3">
+      <!-- Home link -->
+      <a
+        href="/"
+        class="absolute top-4 left-4 sm:top-6 sm:left-6 p-2 rounded-full bg-slate-200 dark:bg-slate-700 hover:bg-slate-300 dark:hover:bg-slate-600 transition-colors"
+        aria-label="Go to home page"
+      >
+        <svg class="h-5 w-5 text-slate-700 dark:text-slate-300" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
+          <path d="M11.47 3.84a.75.75 0 011.06 0l8.69 8.69a.75.75 0 101.06-1.06l-8.689-8.69a2.25 2.25 0 00-3.182 0l-8.69 8.69a.75.75 0 001.061 1.06l8.69-8.69z" />
+          <path d="M12 5.432l8.159 8.159c.03.03.06.058.091.086v6.198c0 1.035-.84 1.875-1.875 1.875H15a.75.75 0 01-.75-.75v-4.5a.75.75 0 00-.75-.75h-3a.75.75 0 00-.75.75V21a.75.75 0 01-.75.75H5.625a1.875 1.875 0 01-1.875-1.875v-6.198a2.29 2.29 0 00.091-.086L12 5.43z" />
+        </svg>
+      </a>
+
       <!-- Dark mode toggle -->
       <button
         id="darkModeToggle"


### PR DESCRIPTION
Add a home icon button in the top left corner of the nuclear page, mirroring the style of the dark mode toggle on the right. Uses a Heroicons home SVG with matching styling and dark mode support.