### PR TITLE
Remove Email button

### DIFF
--- a/home.html
+++ b/home.html
@@ -73,7 +73,6 @@
 </style>
 <div class="home-container">
 <ul class="link-list">
-  <li><a href="#" class="copy-email" data-email="me@bennyhartnett.com">Email</a></li>
   <li><a href="https://www.lionpro.ai/" target="_blank" rel="noopener">Generative AI</a></li>
   
       <li><a href="https://github.com/bennyhartnett" target="_blank" rel="noopener">GitHub</a></li>

--- a/index.html
+++ b/index.html
@@ -399,9 +399,6 @@
                 <div class="home-container">\
                 <ul class="link-list">\
                   <li><a href="https://www.linkedin.com/in/dev-dc" target="_blank" rel="noopener">LinkedIn</a></li>\
-                  <li><a href="#" class="copy-email" data-email="me@bennyhartnett.com">Email</a></li>\
-                  
-                
                 <li><a href="https://github.com/bennyhartnett" target="_blank" rel="noopener">GitHub</a></li>\
                
                  <li><a href="https://www.lionpro.ai/" target="_blank" rel="noopener">Generative AI</a></li>\


### PR DESCRIPTION
The Email copy-to-clipboard button has been removed from both index.html and home.html. The JavaScript handler for .copy-email is preserved as it's still used in privacy.html.