### PR TITLE
Fix contact form page not found error

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -114,7 +114,7 @@
   }
 </style>
 <div class="contact-container">
-  <form class="contact-form" action="https://formly.email/f/385292dab4c64964b1cd656cbc86fba1" method="POST">
+  <form class="contact-form" action="https://formly.email/me@bennyhartnett.com" method="POST">
     <h1>Get in Touch</h1>
     <p>Have a question or want to work together? Send me a message.</p>
 


### PR DESCRIPTION
Revert to the email-based Formly URL format (formly.email/{email}) instead of the form ID format (formly.email/f/{id}) which was returning page not found due to invalid/non-existent form ID.