### PR TITLE
Fix page not found error on form

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -114,7 +114,8 @@
   }
 </style>
 <div class="contact-container">
-  <form class="contact-form" action="https://formly.email/me@bennyhartnett.com" method="POST">
+  <form class="contact-form" action="https://formly.email/submit" method="POST">
+    <input type="hidden" name="access_key" value="385292dab4c64964b1cd656cbc86fba1">
     <h1>Get in Touch</h1>
     <p>Have a question or want to work together? Send me a message.</p>
 


### PR DESCRIPTION
Changed action URL from email-based format to the proper /submit endpoint with access_key hidden field as required by Formly.