### PR TITLE
Fix white screen on page refresh

### DIFF
--- a/404.html
+++ b/404.html
@@ -4,24 +4,19 @@
   <meta charset="UTF-8">
   <title>Redirecting...</title>
   <script>
-    // Handle clean URLs by redirecting to the actual HTML file
-    // e.g., /nuclear -> /nuclear.html
+    // GitHub Pages SPA redirect: store path and redirect to index.html
+    // The SPA will read the stored path and load the correct content
     (function() {
       var path = window.location.pathname;
-      // Remove leading slash and trailing slash if present
+      // Remove leading/trailing slashes
       var page = path.replace(/^\//, '').replace(/\/$/, '');
 
-      if (page) {
-        // Add .html extension if not present
-        if (!page.endsWith('.html')) {
-          page = page + '.html';
-        }
-        // Redirect to the actual HTML file
-        window.location.replace('/' + page);
-      } else {
-        // No path, just go to home
-        window.location.replace('/');
+      if (page && page !== 'index.html') {
+        // Store the requested path for the SPA to handle
+        sessionStorage.setItem('spa-redirect', page);
       }
+      // Redirect to root where index.html will handle routing
+      window.location.replace('/');
     })();
   </script>
   <style>

--- a/index.html
+++ b/index.html
@@ -494,14 +494,23 @@
         }
       });
 
-      // Determine initial page from pathname (clean URL) or hash (legacy)
+      // Determine initial page from pathname, sessionStorage redirect, or hash (legacy)
       let initial = 'home.html';
-      const path = location.pathname.replace(/^\//, '').replace(/\/$/, '');
-      if (path && path !== 'index.html' && path !== '') {
-        initial = path.endsWith('.html') ? path : path + '.html';
-      } else if (location.hash) {
-        initial = location.hash.substring(1);
+
+      // Check for SPA redirect from 404.html
+      const redirectPath = sessionStorage.getItem('spa-redirect');
+      if (redirectPath) {
+        sessionStorage.removeItem('spa-redirect');
+        initial = redirectPath.endsWith('.html') ? redirectPath : redirectPath + '.html';
+      } else {
+        const path = location.pathname.replace(/^\//, '').replace(/\/$/, '');
+        if (path && path !== 'index.html' && path !== '') {
+          initial = path.endsWith('.html') ? path : path + '.html';
+        } else if (location.hash) {
+          initial = location.hash.substring(1);
+        }
       }
+
       const cleanUrl = initial === 'home.html' ? '/' : '/' + initial.replace('.html', '');
       history.replaceState({ url: initial }, '', cleanUrl);
       loadContent(initial, false);


### PR DESCRIPTION
The 404.html was redirecting directly to fragment files (e.g., /contact.html) which are not complete HTML pages. Now 404.html stores the path in sessionStorage and redirects to root, where index.html reads the stored path and loads the correct content within the SPA shell.