### PR TITLE
Fix redirect loop on random links

### DIFF
--- a/index.html
+++ b/index.html
@@ -408,7 +408,10 @@
 
       function loadContent(url, push = true) {
         fetch(url)
-          .then(r => r.text())
+          .then(r => {
+            if (!r.ok) throw new Error('Page not found');
+            return r.text();
+          })
           .then(html => {
             container.innerHTML = html;
             // Execute any inline scripts from the loaded fragment


### PR DESCRIPTION
When fetching a non-existent page, GitHub Pages returns 404.html content. Without checking response.ok, this content (with its redirect script) was being injected and executed, causing an infinite redirect loop. Now we check if the response is ok before processing, and fall through to the inline 404 handler if not.