### PR TITLE
Disable zoom on mobile devices

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 
 <head>
   <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover" />
 
   <!-- Security Headers -->
   <meta http-equiv="X-Content-Type-Options" content="nosniff" />
@@ -371,6 +371,8 @@
       overflow-x: hidden;
       /* allow vertical scrolling if needed */
       overflow-y: auto;
+      /* Disable double-tap zoom on iOS */
+      touch-action: manipulation;
     }
 
     /* Dark mode scrollbar */

--- a/nuclear.html
+++ b/nuclear.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover" />
   <title>Uranium Enrichment Calculators – Tailwind</title>
 
   <!-- Tailwind via CDN -->
@@ -66,6 +66,10 @@
       padding-bottom: env(safe-area-inset-bottom);
       padding-left: env(safe-area-inset-left);
       padding-right: env(safe-area-inset-right);
+    }
+    /* Disable double-tap zoom on iOS */
+    html, body {
+      touch-action: manipulation;
     }
   </style>
 


### PR DESCRIPTION
- Add minimum-scale=1.0 and viewport-fit=cover to viewport meta tags
- Add touch-action: manipulation CSS to prevent double-tap zoom on iOS
- Applied to both index.html and nuclear.html