### PR TITLE
Fix invalid field icon in profile

### DIFF
--- a/index.html
+++ b/index.html
@@ -605,7 +605,7 @@
       <div class="title">Benny Hartnett</div>
 
       
-      <a href="#"><i aria-hidden="true"></i></a>
+      <a href="#" class="search-icon"><i class="fa-solid fa-magnifying-glass" aria-hidden="true"></i></a>
       <button class="menu-toggle" aria-label="Toggle navigation">
         <i class="fa-solid fa-bars"></i>
       </button>


### PR DESCRIPTION
The <i> element was missing its Font Awesome icon class, causing an invalid/empty icon to render. Restored the fa-magnifying-glass icon and search-icon class.