### PR TITLE
Fix invalid field icon in install app

### DIFF
--- a/swu-calculator.mobileconfig
+++ b/swu-calculator.mobileconfig
@@ -7,8 +7,6 @@
         <dict>
             <key>FullScreen</key>
             <true/>
-            <key>Icon</key>
-            <data></data>
             <key>IsRemovable</key>
             <true/>
             <key>Label</key>


### PR DESCRIPTION
The empty <data></data> Icon field was causing "field icon is invalid" error when installing the profile. Removing it lets iOS use the website's favicon automatically.