### PR TITLE
Round corners on bottom elements

### DIFF
--- a/nuclear.html
+++ b/nuclear.html
@@ -228,7 +228,7 @@
     <section id="mode1" class="mb-5">
       <details class="group rounded-xl border border-slate-200 dark:border-slate-600 bg-white dark:bg-slate-700 shadow-sm" open>
         <summary
-          class="flex cursor-pointer items-center justify-between gap-3 rounded-t-xl border-b border-slate-200 dark:border-slate-600 bg-slate-50 dark:bg-slate-700 px-4 py-3 text-sm font-semibold text-slate-800 dark:text-slate-200 transition-colors group-open:bg-slate-100 dark:group-open:bg-slate-600"
+          class="flex cursor-pointer items-center justify-between gap-3 rounded-xl group-open:rounded-b-none border-b border-slate-200 dark:border-slate-600 bg-slate-50 dark:bg-slate-700 px-4 py-3 text-sm font-semibold text-slate-800 dark:text-slate-200 transition-colors group-open:bg-slate-100 dark:group-open:bg-slate-600"
         >
           <span>Feed &amp; SWU for 1&nbsp;kg U EUP</span>
           <svg
@@ -420,7 +420,7 @@
     <section id="mode2" class="mb-5">
       <details class="group rounded-xl border border-slate-200 dark:border-slate-600 bg-white dark:bg-slate-700 shadow-sm">
         <summary
-          class="flex cursor-pointer items-center justify-between gap-3 rounded-t-xl border-b border-slate-200 dark:border-slate-600 bg-slate-50 dark:bg-slate-700 px-4 py-3 text-sm font-semibold text-slate-800 dark:text-slate-200 transition-colors group-open:bg-slate-100 dark:group-open:bg-slate-600"
+          class="flex cursor-pointer items-center justify-between gap-3 rounded-xl group-open:rounded-b-none border-b border-slate-200 dark:border-slate-600 bg-slate-50 dark:bg-slate-700 px-4 py-3 text-sm font-semibold text-slate-800 dark:text-slate-200 transition-colors group-open:bg-slate-100 dark:group-open:bg-slate-600"
         >
           <span>Feed &amp; SWU from EUP Quantity</span>
           <svg
@@ -627,7 +627,7 @@
     <section id="mode3" class="mb-5">
       <details class="group rounded-xl border border-slate-200 dark:border-slate-600 bg-white dark:bg-slate-700 shadow-sm">
         <summary
-          class="flex cursor-pointer items-center justify-between gap-3 rounded-t-xl border-b border-slate-200 dark:border-slate-600 bg-slate-50 dark:bg-slate-700 px-4 py-3 text-sm font-semibold text-slate-800 dark:text-slate-200 transition-colors group-open:bg-slate-100 dark:group-open:bg-slate-600"
+          class="flex cursor-pointer items-center justify-between gap-3 rounded-xl group-open:rounded-b-none border-b border-slate-200 dark:border-slate-600 bg-slate-50 dark:bg-slate-700 px-4 py-3 text-sm font-semibold text-slate-800 dark:text-slate-200 transition-colors group-open:bg-slate-100 dark:group-open:bg-slate-600"
         >
           <span>EUP &amp; SWU from Feed Quantity</span>
           <svg
@@ -811,7 +811,7 @@
     <section id="mode4" class="mb-5">
       <details class="group rounded-xl border border-slate-200 dark:border-slate-600 bg-white dark:bg-slate-700 shadow-sm">
         <summary
-          class="flex cursor-pointer items-center justify-between gap-3 rounded-t-xl border-b border-slate-200 dark:border-slate-600 bg-slate-50 dark:bg-slate-700 px-4 py-3 text-sm font-semibold text-slate-800 dark:text-slate-200 transition-colors group-open:bg-slate-100 dark:group-open:bg-slate-600"
+          class="flex cursor-pointer items-center justify-between gap-3 rounded-xl group-open:rounded-b-none border-b border-slate-200 dark:border-slate-600 bg-slate-50 dark:bg-slate-700 px-4 py-3 text-sm font-semibold text-slate-800 dark:text-slate-200 transition-colors group-open:bg-slate-100 dark:group-open:bg-slate-600"
         >
           <span>Feed &amp; EUP from SWU Quantity</span>
           <svg
@@ -995,7 +995,7 @@
     <section id="mode5">
       <details class="group rounded-xl border border-slate-200 dark:border-slate-600 bg-white dark:bg-slate-700 shadow-sm">
         <summary
-          class="flex cursor-pointer items-center justify-between gap-3 rounded-t-xl border-b border-slate-200 dark:border-slate-600 bg-slate-50 dark:bg-slate-700 px-4 py-3 text-sm font-semibold text-slate-800 dark:text-slate-200 transition-colors group-open:bg-slate-100 dark:group-open:bg-slate-600"
+          class="flex cursor-pointer items-center justify-between gap-3 rounded-xl group-open:rounded-b-none border-b border-slate-200 dark:border-slate-600 bg-slate-50 dark:bg-slate-700 px-4 py-3 text-sm font-semibold text-slate-800 dark:text-slate-200 transition-colors group-open:bg-slate-100 dark:group-open:bg-slate-600"
         >
           <span>Optimum Tails Assay</span>
           <svg


### PR DESCRIPTION
Changed summary elements from rounded-t-xl to rounded-xl with group-open:rounded-b-none so that closed accordions have fully rounded corners instead of square bottom corners.