### PR TITLE
Add iPhone app icon as nuclear page favicon

### DIFF
--- a/nuclear.html
+++ b/nuclear.html
@@ -150,7 +150,8 @@
     }
   </style>
 
-  <!-- Apple Touch Icon for iOS home screen -->
+  <!-- Favicon and Apple Touch Icon -->
+  <link rel="icon" type="image/png" href="/centrus_icon.png" />
   <link rel="apple-touch-icon" href="/centrus_icon.png" />
   <link rel="apple-touch-startup-image" href="/centrus_icon.png" />
   <meta name="apple-mobile-web-app-title" content="SWU Calculator" />


### PR DESCRIPTION
Use the same centrus_icon.png that's used for the iOS home screen icon as the browser tab favicon for consistency.