### PR TITLE
Fix error messages for light and dark mode

### DIFF
--- a/nuclear.html
+++ b/nuclear.html
@@ -135,6 +135,42 @@
       box-shadow: 0 0 0 2px #334155, 0 0 0 4px #14b8a6;
     }
 
+    /* SweetAlert2 dark mode theming */
+    .dark .swal2-popup {
+      background-color: #1e293b; /* slate-800 */
+      color: #f1f5f9; /* slate-100 */
+    }
+    .dark .swal2-title {
+      color: #f1f5f9; /* slate-100 */
+    }
+    .dark .swal2-html-container {
+      color: #cbd5e1; /* slate-300 */
+    }
+    .dark .swal2-icon.swal2-error {
+      border-color: #ef4444; /* red-500 */
+    }
+    .dark .swal2-icon.swal2-error [class^='swal2-x-mark-line'] {
+      background-color: #ef4444; /* red-500 */
+    }
+    .dark .swal2-icon.swal2-warning {
+      border-color: #f59e0b; /* amber-500 */
+      color: #f59e0b;
+    }
+    .dark .swal2-icon.swal2-info {
+      border-color: #3b82f6; /* blue-500 */
+      color: #3b82f6;
+    }
+    .dark .swal2-icon.swal2-success {
+      border-color: #22c55e; /* green-500 */
+      color: #22c55e;
+    }
+    .dark .swal2-icon.swal2-success [class^='swal2-success-line'] {
+      background-color: #22c55e; /* green-500 */
+    }
+    .dark .swal2-icon.swal2-success .swal2-success-ring {
+      border-color: rgba(34, 197, 94, 0.3);
+    }
+
     /* Result shimmer effect on calculation - applies to input group wrapper */
     .result-shimmer {
       animation: result-shimmer-effect 5s ease-out;


### PR DESCRIPTION
SweetAlert2 error popups now follow the light/dark mode setting with appropriate background, text, and icon colors that match the Tailwind slate color palette used throughout the application.