### PR TITLE
Fix arrow styling in dark mode

### DIFF
--- a/nuclear.html
+++ b/nuclear.html
@@ -318,6 +318,11 @@
       background-size: 400% 400%;
       animation: fluid-gradient 15s ease infinite;
     }
+
+    /* Number input spinner (arrows) styling for dark mode */
+    .dark input[type="number"] {
+      color-scheme: dark;
+    }
   </style>
 
   <!-- Favicon and Apple Touch Icon -->


### PR DESCRIPTION
Add color-scheme: dark to number inputs so browser uses dark-themed form controls including spinner arrows.