### PR TITLE
Bump nuclear.js version to bust browser cache

### DIFF
--- a/nuclear.html
+++ b/nuclear.html
@@ -1787,6 +1787,6 @@
   <div id="sr-announcements" aria-live="polite" aria-atomic="true" class="sr-only"></div>
 
   <!-- Calculator logic -->
-  <script src="nuclear.js?v=3"></script>
+  <script src="nuclear.js?v=4"></script>
 </body>
 </html>


### PR DESCRIPTION
Increment cache-busting query string from v=3 to v=4 to ensure
browsers fetch the updated JS with 3 decimal place precision.