### PR TITLE
Fix calculator input group width issue

### DIFF
--- a/nuclear.html
+++ b/nuclear.html
@@ -577,6 +577,7 @@
       background-repeat: no-repeat;
       background-size: 1.25em 1.25em;
       padding-right: 1.75rem;
+      min-width: 5.5rem;
       cursor: pointer;
     }
     .dark .unit-select {


### PR DESCRIPTION
The unit select dropdowns were too narrow, causing the dropdown icon to overlap with the text content like "% U-235". Added a min-width of 5.5rem to ensure adequate space.