### PR TITLE
Fix input group width and arrow overlap

### DIFF
--- a/nuclear.html
+++ b/nuclear.html
@@ -577,7 +577,7 @@
       background-repeat: no-repeat;
       background-size: 1.25em 1.25em;
       padding-right: 1.75rem;
-      min-width: 5.5rem;
+      min-width: 6.5rem;
       cursor: pointer;
     }
     .dark .unit-select {


### PR DESCRIPTION
Increased min-width from 5.5rem to 6.5rem to give more space for the unit text (e.g., "% U-235") and the dropdown arrow.