### PR TITLE
Fix calculator highlight cutoff at edges

### DIFF
--- a/nuclear.html
+++ b/nuclear.html
@@ -474,7 +474,7 @@
       padding-bottom: 1.25rem;
     }
     details > div > * {
-      overflow: hidden;
+      overflow: visible;
     }
     /* Wrapper for accordion content to enable smooth animation */
     details > div > form {


### PR DESCRIPTION
Changed overflow: hidden to overflow: visible on accordion children so box-shadow effects from shimmer animations are no longer clipped. The CSS grid animation technique relies on min-height: 0, not overflow.