### PR TITLE
Fix chat feature 404 and frame options error

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -1,6 +1,6 @@
 // Service Worker for SWU Calculator PWA
 // Version must be updated when deploying new code to bust cache
-const CACHE_VERSION = 'v8';
+const CACHE_VERSION = 'v9';
 const CACHE_NAME = `swu-calculator-${CACHE_VERSION}`;
 
 // Files to cache for offline use
@@ -9,7 +9,9 @@ const STATIC_ASSETS = [
   '/nuclear.html',
   '/nuclear.js',
   '/centrus_icon.png',
-  '/manifest.webmanifest'
+  '/manifest.webmanifest',
+  '/chat',
+  '/pages/chat.html'
 ];
 
 // Install event - cache static assets


### PR DESCRIPTION
The chat page was not included in STATIC_ASSETS, causing users to see cached versions with the old api.bennyhartnett.com endpoint instead of the new Google Apps Script backend.