### PR TITLE
Enlarge chat avatars and sync background colors

### DIFF
--- a/pages/chat.html
+++ b/pages/chat.html
@@ -128,8 +128,8 @@
   }
 
   .message-avatar {
-    width: 36px;
-    height: 36px;
+    width: 44px;
+    height: 44px;
     border-radius: 50%;
     display: flex;
     align-items: center;
@@ -139,7 +139,7 @@
   }
 
   .message.assistant .message-avatar {
-    background: linear-gradient(135deg, rgba(99, 102, 241, 0.8), rgba(168, 85, 247, 0.8));
+    background: var(--wave-color, #6366f1);
     padding: 0;
     overflow: hidden;
   }
@@ -151,7 +151,7 @@
   }
 
   .message.user .message-avatar {
-    background: rgba(255, 255, 255, 0.15);
+    background: color-mix(in srgb, var(--wave-color, #6366f1) 30%, transparent);
   }
 
   .message-content {

--- a/sw.js
+++ b/sw.js
@@ -1,6 +1,6 @@
 // Service Worker for SWU Calculator PWA
 // Version must be updated when deploying new code to bust cache
-const CACHE_VERSION = 'v11';
+const CACHE_VERSION = 'v12';
 const CACHE_NAME = `swu-calculator-${CACHE_VERSION}`;
 
 // Files to cache for offline use


### PR DESCRIPTION
- Increase avatar size from 36px to 44px
- Assistant avatar background now uses --wave-color
- User avatar background uses a translucent version of --wave-color