### PR TITLE
Add current date and time to LLM context

### DIFF
--- a/pages/chat.html
+++ b/pages/chat.html
@@ -892,8 +892,19 @@ END OF SOURCE OF TRUTH
 
     try {
       // Prepare messages for API call with system message first
+      // Include current date/time for temporal context
+      const currentDateTime = new Date().toLocaleString('en-US', {
+        weekday: 'long',
+        year: 'numeric',
+        month: 'long',
+        day: 'numeric',
+        hour: 'numeric',
+        minute: '2-digit',
+        timeZoneName: 'short'
+      });
+      const contextWithDateTime = `${bennyContext}\n\nCURRENT DATE AND TIME: ${currentDateTime}`;
       const messages = [
-        { role: 'system', content: bennyContext },
+        { role: 'system', content: contextWithDateTime },
         ...conversationHistory
       ];
 

--- a/sw.js
+++ b/sw.js
@@ -1,6 +1,6 @@
 // Service Worker for SWU Calculator PWA
 // Version must be updated when deploying new code to bust cache
-const CACHE_VERSION = 'v15';
+const CACHE_VERSION = 'v16';
 const CACHE_NAME = `swu-calculator-${CACHE_VERSION}`;
 
 // Files to cache for offline use


### PR DESCRIPTION
Append the current date and time to the system prompt so the LLM has temporal awareness when responding to user messages.