### PR TITLE
Optimize chat markdown rendering and link styling

### DIFF
--- a/pages/chat.html
+++ b/pages/chat.html
@@ -188,8 +188,35 @@
   }
 
   .message-content a {
-    color: #93c5fd;
-    text-decoration: underline;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+    padding: 0.25rem 0.625rem;
+    border-radius: 9999px;
+    font-size: 0.8125em;
+    font-weight: 500;
+    text-decoration: none;
+    transition: all 0.2s ease;
+    background: color-mix(in srgb, var(--wave-color, #6366f1) 25%, transparent);
+    color: white;
+    border: 1px solid color-mix(in srgb, var(--wave-color, #6366f1) 40%, transparent);
+  }
+
+  .message-content a:hover {
+    background: color-mix(in srgb, var(--wave-color, #6366f1) 45%, transparent);
+    border-color: color-mix(in srgb, var(--wave-color, #6366f1) 60%, transparent);
+    transform: translateY(-1px);
+  }
+
+  .message-content a::after {
+    content: '↗';
+    font-size: 0.75em;
+    opacity: 0.7;
+  }
+
+  .message-content a[href^="/"]::after,
+  .message-content a[href^="#"]::after {
+    content: '→';
   }
 
   .message-content code {
@@ -197,6 +224,72 @@
     padding: 0.125rem 0.375rem;
     border-radius: 4px;
     font-size: 0.875em;
+    font-family: 'SF Mono', 'Monaco', 'Inconsolata', 'Fira Mono', monospace;
+  }
+
+  .message-content pre {
+    background: rgba(0, 0, 0, 0.4);
+    border-radius: 8px;
+    padding: 0.75rem 1rem;
+    overflow-x: auto;
+    margin: 0.5rem 0;
+    border: 1px solid rgba(255, 255, 255, 0.1);
+  }
+
+  .message-content pre code {
+    background: none;
+    padding: 0;
+    font-size: 0.85em;
+    line-height: 1.5;
+  }
+
+  .message-content h1, .message-content h2, .message-content h3,
+  .message-content h4, .message-content h5, .message-content h6 {
+    margin: 0.75rem 0 0.5rem 0;
+    font-weight: 600;
+    line-height: 1.3;
+  }
+
+  .message-content h1:first-child, .message-content h2:first-child,
+  .message-content h3:first-child {
+    margin-top: 0;
+  }
+
+  .message-content h1 { font-size: 1.25em; }
+  .message-content h2 { font-size: 1.15em; }
+  .message-content h3 { font-size: 1.05em; }
+  .message-content h4, .message-content h5, .message-content h6 { font-size: 1em; }
+
+  .message-content ul, .message-content ol {
+    margin: 0.5rem 0;
+    padding-left: 1.5rem;
+  }
+
+  .message-content li {
+    margin: 0.25rem 0;
+    line-height: 1.5;
+  }
+
+  .message-content ul li {
+    list-style-type: disc;
+  }
+
+  .message-content ol li {
+    list-style-type: decimal;
+  }
+
+  .message-content hr {
+    border: none;
+    border-top: 1px solid rgba(255, 255, 255, 0.15);
+    margin: 0.75rem 0;
+  }
+
+  .message-content blockquote {
+    border-left: 3px solid color-mix(in srgb, var(--wave-color, #6366f1) 60%, transparent);
+    padding-left: 0.75rem;
+    margin: 0.5rem 0;
+    color: rgba(255, 255, 255, 0.8);
+    font-style: italic;
   }
 
   .chat-input-container {
@@ -841,13 +934,75 @@ END OF SOURCE OF TRUTH
   }
 
   function formatMessage(text) {
-    // Convert markdown-style formatting to HTML
-    return text
-      .replace(/\*\*(.*?)\*\*/g, '<strong>$1</strong>')
-      .replace(/\*(.*?)\*/g, '<em>$1</em>')
-      .replace(/`(.*?)`/g, '<code>$1</code>')
-      .replace(/\n/g, '<br>')
-      .replace(/\[(.*?)\]\((.*?)\)/g, '<a href="$2" target="_blank" rel="noopener">$1</a>');
+    // Comprehensive markdown parser
+    let html = text;
+
+    // Escape HTML entities first (but preserve our markdown)
+    html = html.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+
+    // Code blocks (must be done before other processing)
+    html = html.replace(/```(\w*)\n?([\s\S]*?)```/g, (match, lang, code) => {
+      return `<pre><code>${code.trim()}</code></pre>`;
+    });
+
+    // Inline code (protect from other formatting)
+    const codeBlocks = [];
+    html = html.replace(/`([^`]+)`/g, (match, code) => {
+      codeBlocks.push(`<code>${code}</code>`);
+      return `\x00CODE${codeBlocks.length - 1}\x00`;
+    });
+
+    // Headers (must be at start of line)
+    html = html.replace(/^######\s+(.+)$/gm, '<h6>$1</h6>');
+    html = html.replace(/^#####\s+(.+)$/gm, '<h5>$1</h5>');
+    html = html.replace(/^####\s+(.+)$/gm, '<h4>$1</h4>');
+    html = html.replace(/^###\s+(.+)$/gm, '<h3>$1</h3>');
+    html = html.replace(/^##\s+(.+)$/gm, '<h2>$1</h2>');
+    html = html.replace(/^#\s+(.+)$/gm, '<h1>$1</h1>');
+
+    // Horizontal rules
+    html = html.replace(/^---+$/gm, '<hr>');
+    html = html.replace(/^\*\*\*+$/gm, '<hr>');
+
+    // Blockquotes
+    html = html.replace(/^>\s+(.+)$/gm, '<blockquote>$1</blockquote>');
+
+    // Bold and italic (order matters: bold first, then italic)
+    html = html.replace(/\*\*\*(.+?)\*\*\*/g, '<strong><em>$1</em></strong>');
+    html = html.replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>');
+    html = html.replace(/\*(.+?)\*/g, '<em>$1</em>');
+    html = html.replace(/_(.+?)_/g, '<em>$1</em>');
+
+    // Links
+    html = html.replace(/\[([^\]]+)\]\(([^)]+)\)/g, (match, linkText, url) => {
+      const isInternal = url.startsWith('/') || url.startsWith('#');
+      const target = isInternal ? '' : ' target="_blank" rel="noopener"';
+      return `<a href="${url}"${target}>${linkText}</a>`;
+    });
+
+    // Unordered lists
+    html = html.replace(/^[\*\-]\s+(.+)$/gm, '<li>$1</li>');
+
+    // Ordered lists
+    html = html.replace(/^\d+\.\s+(.+)$/gm, '<li>$1</li>');
+
+    // Wrap consecutive list items in ul/ol
+    html = html.replace(/(<li>.*<\/li>\n?)+/g, (match) => {
+      return `<ul>${match}</ul>`;
+    });
+
+    // Clean up multiple consecutive blockquotes
+    html = html.replace(/<\/blockquote>\n<blockquote>/g, '<br>');
+
+    // Convert remaining newlines to <br> (but not after block elements)
+    html = html.replace(/\n(?!<)/g, '<br>');
+    html = html.replace(/<br>(<\/?(ul|ol|li|h[1-6]|pre|blockquote|hr))/g, '$1');
+    html = html.replace(/(<\/(ul|ol|h[1-6]|pre|blockquote)>)<br>/g, '$1');
+
+    // Restore inline code blocks
+    html = html.replace(/\x00CODE(\d+)\x00/g, (match, index) => codeBlocks[parseInt(index)]);
+
+    return html;
   }
 
   function addTypingIndicator() {

--- a/sw.js
+++ b/sw.js
@@ -1,6 +1,6 @@
 // Service Worker for SWU Calculator PWA
 // Version must be updated when deploying new code to bust cache
-const CACHE_VERSION = 'v17';
+const CACHE_VERSION = 'v18';
 const CACHE_NAME = `swu-calculator-${CACHE_VERSION}`;
 
 // Files to cache for offline use


### PR DESCRIPTION
- Add comprehensive markdown parser supporting headers, lists, code blocks, blockquotes, and horizontal rules
- Style links as pill-shaped badges with wave-color background that changes based on the site theme
- Add external link indicator (arrow) for external URLs
- Improve code block styling with monospace font and dark background
- Add proper list styling for ordered and unordered lists
- Increment cache version to v18