### PR TITLE
Match chat background color to AI Benny

### DIFF
--- a/pages/chat.html
+++ b/pages/chat.html
@@ -21,7 +21,7 @@
     text-align: center;
     margin-bottom: 1.5rem;
     padding-bottom: 1rem;
-    border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+    border-bottom: 1px solid color-mix(in srgb, var(--wave-color, #6366f1) 30%, rgba(255, 255, 255, 0.1));
   }
 
   .chat-header h1 {
@@ -168,10 +168,10 @@
   }
 
   .message.assistant .message-content {
-    background: rgba(255, 255, 255, 0.08);
+    background: color-mix(in srgb, var(--wave-color, #6366f1) 10%, rgba(255, 255, 255, 0.08));
     backdrop-filter: blur(12px);
     -webkit-backdrop-filter: blur(12px);
-    border: 1px solid rgba(255, 255, 255, 0.12);
+    border: 1px solid color-mix(in srgb, var(--wave-color, #6366f1) 20%, rgba(255, 255, 255, 0.12));
     border-radius: 16px 16px 16px 4px;
   }
 
@@ -203,11 +203,11 @@
   .chat-input-container {
     position: sticky;
     bottom: 1rem;
-    background: rgba(0, 0, 0, 0.6);
+    background: color-mix(in srgb, var(--wave-color, #6366f1) 15%, rgba(0, 0, 0, 0.6));
     backdrop-filter: blur(20px);
     -webkit-backdrop-filter: blur(20px);
     border-radius: 24px;
-    border: 1px solid rgba(255, 255, 255, 0.15);
+    border: 1px solid color-mix(in srgb, var(--wave-color, #6366f1) 30%, rgba(255, 255, 255, 0.15));
     padding: 0.5rem;
     display: flex;
     gap: 0.5rem;
@@ -291,7 +291,7 @@
     width: 8px;
     height: 8px;
     border-radius: 50%;
-    background: rgba(255, 255, 255, 0.5);
+    background: color-mix(in srgb, var(--wave-color, #6366f1) 60%, rgba(255, 255, 255, 0.5));
     animation: typing 1.4s infinite;
   }
 
@@ -352,8 +352,8 @@
   }
 
   .suggestion-chip {
-    background: rgba(255, 255, 255, 0.08);
-    border: 1px solid rgba(255, 255, 255, 0.15);
+    background: color-mix(in srgb, var(--wave-color, #6366f1) 10%, rgba(255, 255, 255, 0.08));
+    border: 1px solid color-mix(in srgb, var(--wave-color, #6366f1) 20%, rgba(255, 255, 255, 0.15));
     border-radius: 20px;
     padding: 0.5rem 1rem;
     font-size: 0.875rem;
@@ -369,7 +369,7 @@
   .suggestion-chip:nth-child(4) { animation-delay: 0.4s; }
 
   .suggestion-chip:hover {
-    background: rgba(255, 255, 255, 0.12);
+    background: color-mix(in srgb, var(--wave-color, #6366f1) 25%, rgba(255, 255, 255, 0.12));
     border-color: var(--wave-color, #6366f1);
     color: white;
   }
@@ -382,11 +382,11 @@
     background: transparent;
   }
   ::-webkit-scrollbar-thumb {
-    background: rgba(255, 255, 255, 0.2);
+    background: color-mix(in srgb, var(--wave-color, #6366f1) 40%, rgba(255, 255, 255, 0.2));
     border-radius: 4px;
   }
   ::-webkit-scrollbar-thumb:hover {
-    background: rgba(255, 255, 255, 0.3);
+    background: color-mix(in srgb, var(--wave-color, #6366f1) 50%, rgba(255, 255, 255, 0.3));
   }
 
   @media (max-width: 600px) {

--- a/sw.js
+++ b/sw.js
@@ -1,6 +1,6 @@
 // Service Worker for SWU Calculator PWA
 // Version must be updated when deploying new code to bust cache
-const CACHE_VERSION = 'v20';
+const CACHE_VERSION = 'v21';
 const CACHE_NAME = `swu-calculator-${CACHE_VERSION}`;
 
 // Files to cache for offline use


### PR DESCRIPTION
Update chat elements to use color-mix with --wave-color CSS variable so they subtly shift with the background wave animation:
- Chat input container background and border
- Assistant message bubbles
- Suggestion chips
- Chat header border
- Scrollbar
- Typing indicator dots