### PR TITLE
Optimize chat markdown rendering and link styling

### DIFF
--- a/pages/chat.html
+++ b/pages/chat.html
@@ -188,16 +188,162 @@
     margin-bottom: 0;
   }
 
+  /* Badge-styled links with dynamic color */
   .message-content a {
-    color: #93c5fd;
-    text-decoration: underline;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+    background: color-mix(in srgb, var(--wave-color, #6366f1) 20%, transparent);
+    color: color-mix(in srgb, var(--wave-color, #6366f1) 100%, white 30%);
+    text-decoration: none;
+    padding: 0.2rem 0.6rem;
+    border-radius: 9999px;
+    font-size: 0.85em;
+    font-weight: 500;
+    border: 1px solid color-mix(in srgb, var(--wave-color, #6366f1) 40%, transparent);
+    transition: all 0.2s ease;
+    white-space: nowrap;
   }
 
+  .message-content a:hover {
+    background: color-mix(in srgb, var(--wave-color, #6366f1) 35%, transparent);
+    border-color: color-mix(in srgb, var(--wave-color, #6366f1) 60%, transparent);
+    transform: translateY(-1px);
+  }
+
+  .message-content a::before {
+    content: '→';
+    font-size: 0.75em;
+    opacity: 0.7;
+  }
+
+  /* Inline code */
   .message-content code {
     background: rgba(0, 0, 0, 0.3);
     padding: 0.125rem 0.375rem;
     border-radius: 4px;
     font-size: 0.875em;
+    font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', monospace;
+  }
+
+  /* Code blocks */
+  .message-content pre {
+    background: rgba(0, 0, 0, 0.4);
+    border-radius: 8px;
+    padding: 1rem;
+    overflow-x: auto;
+    margin: 0.75rem 0;
+    border: 1px solid rgba(255, 255, 255, 0.1);
+  }
+
+  .message-content pre code {
+    background: none;
+    padding: 0;
+    font-size: 0.85em;
+    line-height: 1.6;
+  }
+
+  /* Headings */
+  .message-content h1,
+  .message-content h2,
+  .message-content h3,
+  .message-content h4 {
+    margin: 1rem 0 0.5rem 0;
+    font-weight: 600;
+    line-height: 1.3;
+  }
+
+  .message-content h1 { font-size: 1.25em; }
+  .message-content h2 { font-size: 1.15em; }
+  .message-content h3 { font-size: 1.05em; }
+  .message-content h4 { font-size: 1em; }
+
+  .message-content h1:first-child,
+  .message-content h2:first-child,
+  .message-content h3:first-child,
+  .message-content h4:first-child {
+    margin-top: 0;
+  }
+
+  /* Lists */
+  .message-content ul,
+  .message-content ol {
+    margin: 0.5rem 0;
+    padding-left: 1.5rem;
+  }
+
+  .message-content li {
+    margin: 0.25rem 0;
+    line-height: 1.5;
+  }
+
+  .message-content ul li {
+    list-style-type: disc;
+  }
+
+  .message-content ol li {
+    list-style-type: decimal;
+  }
+
+  .message-content li > ul,
+  .message-content li > ol {
+    margin: 0.25rem 0;
+  }
+
+  /* Blockquotes */
+  .message-content blockquote {
+    border-left: 3px solid var(--wave-color, #6366f1);
+    margin: 0.75rem 0;
+    padding: 0.5rem 0 0.5rem 1rem;
+    background: rgba(255, 255, 255, 0.03);
+    border-radius: 0 4px 4px 0;
+    font-style: italic;
+    color: rgba(255, 255, 255, 0.85);
+  }
+
+  .message-content blockquote p {
+    margin: 0;
+  }
+
+  /* Horizontal rules */
+  .message-content hr {
+    border: none;
+    border-top: 1px solid rgba(255, 255, 255, 0.15);
+    margin: 1rem 0;
+  }
+
+  /* Tables */
+  .message-content table {
+    width: 100%;
+    border-collapse: collapse;
+    margin: 0.75rem 0;
+    font-size: 0.9em;
+  }
+
+  .message-content th,
+  .message-content td {
+    padding: 0.5rem 0.75rem;
+    text-align: left;
+    border: 1px solid rgba(255, 255, 255, 0.15);
+  }
+
+  .message-content th {
+    background: rgba(255, 255, 255, 0.08);
+    font-weight: 600;
+  }
+
+  .message-content tr:nth-child(even) {
+    background: rgba(255, 255, 255, 0.03);
+  }
+
+  /* Strong and emphasis */
+  .message-content strong {
+    font-weight: 600;
+    color: white;
+  }
+
+  .message-content em {
+    font-style: italic;
   }
 
   .chat-input-container {
@@ -435,9 +581,35 @@
   </div>
 </div>
 
+<!-- Marked.js for markdown rendering -->
+<script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+
 <script>
 (function() {
   const BACKEND_URL = 'https://script.google.com/macros/s/AKfycbz0h40oJSvKksAq9KHTxqh1YBHAaJfh6vw8E0kwEy-zXG14noT8-836BWuuxXN2Xar1yg/exec';
+
+  // Configure marked.js for safe rendering
+  marked.setOptions({
+    breaks: true,        // Convert \n to <br>
+    gfm: true,           // GitHub Flavored Markdown
+    headerIds: false,    // Don't add IDs to headers
+    mangle: false        // Don't mangle email addresses
+  });
+
+  // Custom renderer to add target="_blank" to links
+  const renderer = new marked.Renderer();
+  renderer.link = function(href, title, text) {
+    // Handle marked v5+ API changes
+    if (typeof href === 'object') {
+      const token = href;
+      href = token.href;
+      title = token.title;
+      text = token.text;
+    }
+    const titleAttr = title ? ` title="${title}"` : '';
+    return `<a href="${href}" target="_blank" rel="noopener noreferrer"${titleAttr}>${text}</a>`;
+  };
+  marked.use({ renderer });
 
   // Email obfuscation - assembled at runtime to prevent scraping
   const _e = ['m','e','@','b','e','n','n','y','h','a','r','t','n','e','t','t','.','c','o','m'];
@@ -842,13 +1014,9 @@ END OF SOURCE OF TRUTH
   }
 
   function formatMessage(text) {
-    // Convert markdown-style formatting to HTML
-    return text
-      .replace(/\*\*(.*?)\*\*/g, '<strong>$1</strong>')
-      .replace(/\*(.*?)\*/g, '<em>$1</em>')
-      .replace(/`(.*?)`/g, '<code>$1</code>')
-      .replace(/\n/g, '<br>')
-      .replace(/\[(.*?)\]\((.*?)\)/g, '<a href="$2" target="_blank" rel="noopener">$1</a>');
+    // Use marked.js for full markdown rendering
+    // Parse the markdown and return HTML
+    return marked.parse(text);
   }
 
   function addTypingIndicator() {

--- a/sw.js
+++ b/sw.js
@@ -1,6 +1,6 @@
 // Service Worker for SWU Calculator PWA
 // Version must be updated when deploying new code to bust cache
-const CACHE_VERSION = 'v19';
+const CACHE_VERSION = 'v20';
 const CACHE_NAME = `swu-calculator-${CACHE_VERSION}`;
 
 // Files to cache for offline use


### PR DESCRIPTION
- Integrate marked.js for full GitHub Flavored Markdown support
- Add CSS styles for headings, lists, code blocks, blockquotes, tables
- Style links as dynamic color badges matching --wave-color
- Links have pill/badge appearance with arrow icon and hover effects
- Increment cache version to v20