### PR TITLE
Force dark mode across entire site

### DIFF
--- a/404.html
+++ b/404.html
@@ -2,6 +2,8 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
+  <meta name="color-scheme" content="dark">
   <title>Redirecting...</title>
   <script>
     // GitHub Pages SPA redirect: store path and redirect to index.html
@@ -20,15 +22,34 @@
     })();
   </script>
   <style>
+    :root {
+      color-scheme: dark;
+    }
+    html {
+      -webkit-text-size-adjust: 100%;
+      background: #000;
+    }
+    html, body {
+      background: #000;
+      color: #fff;
+      margin: 0;
+    }
     body {
-      background: #111;
-      color: white;
       font-family: sans-serif;
       display: flex;
       justify-content: center;
       align-items: center;
       height: 100vh;
-      margin: 0;
+      overscroll-behavior: none;
+    }
+    @supports (-webkit-touch-callout: none) {
+      body {
+        padding-top: env(safe-area-inset-top);
+        padding-bottom: env(safe-area-inset-bottom);
+      }
+    }
+    * {
+      -webkit-tap-highlight-color: rgba(255, 255, 255, 0.05);
     }
   </style>
 </head>

--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover" />
+  <meta name="color-scheme" content="dark" />
 
   <!-- Security Headers -->
   <meta http-equiv="X-Content-Type-Options" content="nosniff" />
@@ -377,6 +378,12 @@
 
     :root {
       --wave-color: blue;
+      color-scheme: dark;
+    }
+
+    html {
+      -webkit-text-size-adjust: 100%;
+      background: #000;
     }
 
     html,
@@ -389,6 +396,49 @@
       overflow-y: auto;
       /* Disable double-tap zoom on iOS */
       touch-action: manipulation;
+      background: #000;
+      color: #fff;
+    }
+
+    body {
+      overscroll-behavior: none;
+    }
+
+    /* iOS Safari dark mode safe areas */
+    @supports (-webkit-touch-callout: none) {
+      html, body {
+        margin: 0;
+        background: #000;
+        color: #fff;
+      }
+
+      body {
+        padding-top: env(safe-area-inset-top);
+        padding-bottom: env(safe-area-inset-bottom);
+        overscroll-behavior: none;
+      }
+    }
+
+    /* Tap highlight for dark mode */
+    * {
+      -webkit-tap-highlight-color: rgba(255, 255, 255, 0.05);
+    }
+
+    /* Dark mode form controls */
+    input,
+    textarea,
+    select {
+      background-color: #111;
+      color: #fff;
+      -webkit-appearance: none;
+    }
+
+    /* Reinforce dark mode for system */
+    @media (prefers-color-scheme: dark) {
+      html, body {
+        background: #000;
+        color: #fff;
+      }
     }
 
     /* Dark mode scrollbar */

--- a/sw.js
+++ b/sw.js
@@ -1,6 +1,6 @@
 // Service Worker for SWU Calculator PWA
 // Version must be updated when deploying new code to bust cache
-const CACHE_VERSION = 'v23';
+const CACHE_VERSION = 'v24';
 const CACHE_NAME = `swu-calculator-${CACHE_VERSION}`;
 
 // Files to cache for offline use

--- a/tools/og-image-generator.html
+++ b/tools/og-image-generator.html
@@ -2,15 +2,39 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
+  <meta name="color-scheme" content="dark">
   <title>OG Image Generator</title>
   <style>
-    * { box-sizing: border-box; margin: 0; padding: 0; }
+    :root {
+      color-scheme: dark;
+    }
+    * {
+      box-sizing: border-box;
+      margin: 0;
+      padding: 0;
+      -webkit-tap-highlight-color: rgba(255, 255, 255, 0.05);
+    }
+    html {
+      -webkit-text-size-adjust: 100%;
+      background: #000;
+    }
+    html, body {
+      background: #000;
+      color: #fff;
+    }
     body {
       font-family: system-ui, -apple-system, sans-serif;
       background: #0f172a;
       color: #f8fafc;
       padding: 2rem;
+      overscroll-behavior: none;
+    }
+    @supports (-webkit-touch-callout: none) {
+      body {
+        padding-top: calc(2rem + env(safe-area-inset-top));
+        padding-bottom: calc(2rem + env(safe-area-inset-bottom));
+      }
     }
     h1 { margin-bottom: 1rem; }
     p { color: #94a3b8; margin-bottom: 2rem; }


### PR DESCRIPTION
- Add color-scheme: dark meta tag and CSS declaration
- Add iOS safe area inset padding for status bar/home indicator
- Add overscroll-behavior: none to prevent white flash on bounce
- Add -webkit-text-size-adjust and tap highlight overrides
- Darken input/textarea/select form controls
- Add prefers-color-scheme media query reinforcement
- Update viewport meta for viewport-fit: cover
- Increment CACHE_VERSION to v24

Excludes nuclear.html as requested.