### PR TITLE
Fix Three.js background not displaying

### DIFF
--- a/index.html
+++ b/index.html
@@ -663,6 +663,8 @@
   <script type="module">
     import { initWaveBackground } from "./wave-background.js";
     window.initWaveBackground = initWaveBackground;
+    // Initialize immediately since modules execute after DOM is ready
+    initWaveBackground();
   </script>
   <!-- Google tag (gtag.js) -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-GGGPH0X4LN"></script>
@@ -693,9 +695,8 @@
   </main>
 
   <script>
-    // Initialize background when loaded
+    // Initialize SPA router when DOM is ready
     window.addEventListener('DOMContentLoaded', () => {
-      window.initWaveBackground();
       const container = document.querySelector('#main-content');
       const canonicalTag = document.getElementById('canonical-link');
       const ogUrlTag = document.getElementById('og-url');

--- a/sw.js
+++ b/sw.js
@@ -1,6 +1,6 @@
 // Service Worker for SWU Calculator PWA
 // Version must be updated when deploying new code to bust cache
-const CACHE_VERSION = 'v25';
+const CACHE_VERSION = 'v26';
 const CACHE_NAME = `swu-calculator-${CACHE_VERSION}`;
 
 // Files to cache for offline use


### PR DESCRIPTION
Move initWaveBackground() call into the module script itself instead of relying on DOMContentLoaded, since ES modules are deferred and may not finish importing before DOMContentLoaded fires.