### PR TITLE
Fix contact subdomain routing issue

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -1,6 +1,6 @@
 // Service Worker for SWU Calculator PWA
 // Version must be updated when deploying new code to bust cache
-const CACHE_VERSION = 'v27';
+const CACHE_VERSION = 'v28';
 const CACHE_NAME = `swu-calculator-${CACHE_VERSION}`;
 
 // Files to cache for offline use


### PR DESCRIPTION
- Map subdomain requests (e.g., contact.bennyhartnett.com) to /pages/{subdomain}.html
- Add X-Internal-Fetch header to prevent redirect loops on internal fetches
- Add 'pages' to EXCLUDED_PATHS to prevent /pages/ from redirecting
- Bump cache version to v28