### PR TITLE
Fix missing page content after redirects

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -1,6 +1,6 @@
 // Service Worker for SWU Calculator PWA
 // Version must be updated when deploying new code to bust cache
-const CACHE_VERSION = 'v28';
+const CACHE_VERSION = 'v29';
 const CACHE_NAME = `swu-calculator-${CACHE_VERSION}`;
 
 // Files to cache for offline use

--- a/workers/router.js
+++ b/workers/router.js
@@ -20,6 +20,7 @@ const EXCLUDED_PATHS = [
   'images',
   'css',
   'js',
+  'pages',
   '.well-known',
 ];
 
@@ -56,7 +57,8 @@ async function handleSubdomain(request, url, hostname) {
   const subdomain = hostname.replace(`.${ROOT_DOMAIN}`, '');
 
   // For static assets on subdomain, try to fetch from main domain
-  const isStaticAsset = url.pathname.match(/\.(js|css|png|jpg|jpeg|gif|svg|ico|woff|woff2|ttf|eot|json|pdf|webp)$/i);
+  // NOTE: .html is included to allow SPA to fetch page fragments (e.g., pages/contact.html)
+  const isStaticAsset = url.pathname.match(/\.(js|css|png|jpg|jpeg|gif|svg|ico|woff|woff2|ttf|eot|json|pdf|webp|html)$/i);
 
   if (isStaticAsset) {
     // Fetch static asset from main domain


### PR DESCRIPTION
The Cloudflare Worker wasn't treating .html files as static assets, so when the SPA on subdomains tried to fetch page fragments (e.g., pages/contact.html), it received index.html instead of the actual content. Added .html to the static asset pattern and 'pages' to excluded paths.