### PR TITLE
Restore missing chat button

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -1,11 +1,14 @@
 // Service Worker for SWU Calculator PWA
 // Version must be updated when deploying new code to bust cache
-const CACHE_VERSION = 'v29';
+const CACHE_VERSION = 'v30';
 const CACHE_NAME = `swu-calculator-${CACHE_VERSION}`;
 
 // Files to cache for offline use
 // Note: Only include actual files, not SPA routes (like /chat which redirects)
 const STATIC_ASSETS = [
+  '/',
+  '/index.html',
+  '/pages/home.html',
   '/nuclear',
   '/nuclear.html',
   '/nuclear.js',


### PR DESCRIPTION
Add home page to service worker static assets and increment cache version to v30 to ensure the floating chat button is visible.