### PR TITLE
Fix resume PDF viewer not displaying

### DIFF
--- a/index.html
+++ b/index.html
@@ -982,8 +982,11 @@
           return;
         }
         // Handle clean URLs (e.g., /resume, /contact) and .html URLs
-        const isCleanUrl = href && href.startsWith('/') && !href.startsWith('http') && href !== '/';
-        const isHtmlUrl = href && href.endsWith('.html') && !href.startsWith('http');
+        // Exclude asset paths from subdomain redirect (same as worker EXCLUDED_PATHS)
+        const excludedPrefixes = ['/assets', '/images', '/css', '/js', '/pages', '/.well-known'];
+        const isExcludedPath = excludedPrefixes.some(prefix => href.startsWith(prefix));
+        const isCleanUrl = href && href.startsWith('/') && !href.startsWith('http') && href !== '/' && !isExcludedPath;
+        const isHtmlUrl = href && href.endsWith('.html') && !href.startsWith('http') && !isExcludedPath;
         if (isCleanUrl || isHtmlUrl) {
           e.preventDefault();
           let pageName;

--- a/pages/resume.html
+++ b/pages/resume.html
@@ -14,8 +14,9 @@
 <script>
 (function() {
   // Set iframe src via JS to prevent static scraping
-  var p = ['/', 'assets', '/d/', 'r-', '8f3a', '2c9e', '7b1d', '.pdf'];
-  var url = p[0] + p[1] + p[2] + p[3] + p[4] + p[5] + p[6] + p[7];
+  // Use absolute URL to main domain to avoid subdomain routing issues
+  var p = ['https://', 'benny', 'hartnett', '.com', '/assets', '/d/', 'r-', '8f3a', '2c9e', '7b1d', '.pdf'];
+  var url = p[0] + p[1] + p[2] + p[3] + p[4] + p[5] + p[6] + p[7] + p[8] + p[9] + p[10];
   document.getElementById('resume-iframe').src = url;
 })();
 </script>

--- a/sw.js
+++ b/sw.js
@@ -1,6 +1,6 @@
 // Service Worker for SWU Calculator PWA
 // Version must be updated when deploying new code to bust cache
-const CACHE_VERSION = 'v29';
+const CACHE_VERSION = 'v30';
 const CACHE_NAME = `swu-calculator-${CACHE_VERSION}`;
 
 // Files to cache for offline use


### PR DESCRIPTION
- Add excluded path prefixes to click handler to prevent asset URLs from being converted to subdomain redirects (matching worker EXCLUDED_PATHS)
- Update resume.html to use absolute URL to main domain for PDF iframe
- Increment cache version to v30