### PR TITLE
Prevent message sending while AI is processing

### DIFF
--- a/pages/chat.html
+++ b/pages/chat.html
@@ -1150,6 +1150,7 @@ END OF SOURCE OF TRUTH
 
   async function sendMessage(userMessage) {
     if (!userMessage.trim()) return;
+    if (sendButton.disabled) return; // Prevent sending while AI is responding
 
     // Add user message to UI
     addMessage(userMessage, 'user');

--- a/sw.js
+++ b/sw.js
@@ -1,6 +1,6 @@
 // Service Worker for SWU Calculator PWA
 // Version must be updated when deploying new code to bust cache
-const CACHE_VERSION = 'v31';
+const CACHE_VERSION = 'v32';
 const CACHE_NAME = `swu-calculator-${CACHE_VERSION}`;
 
 // Files to cache for offline use


### PR DESCRIPTION
Add guard in sendMessage() to prevent multiple sends when the send button is disabled, ensuring users cannot send messages via Enter key or suggestion chips while the AI is still processing a response.