### PR TITLE
Fix Contact display in right corner

### DIFF
--- a/index.html
+++ b/index.html
@@ -699,7 +699,6 @@
     <div class="nav-header">
       <div class="title" tabindex="0" role="button" aria-label="Go to home page">Benny Hartnett</div>
       <div class="menu">
-        <a data-href="/contact">Contact</a>
       </div>
     </div>
   </nav>

--- a/sw.js
+++ b/sw.js
@@ -1,6 +1,6 @@
 // Service Worker for SWU Calculator PWA
 // Version must be updated when deploying new code to bust cache
-const CACHE_VERSION = 'v31';
+const CACHE_VERSION = 'v32';
 const CACHE_NAME = `swu-calculator-${CACHE_VERSION}`;
 
 // Files to cache for offline use


### PR DESCRIPTION
Contact is already displayed in the home page link list, so having it in the top right nav bar was unnecessary duplication.