### PR TITLE
Fix website display without requiring reload

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -1,6 +1,6 @@
 // Service Worker for SWU Calculator PWA
 // Version must be updated when deploying new code to bust cache
-const CACHE_VERSION = 'v32';
+const CACHE_VERSION = 'v33';
 const CACHE_NAME = `swu-calculator-${CACHE_VERSION}`;
 
 // Files to cache for offline use

--- a/workers/router.js
+++ b/workers/router.js
@@ -52,6 +52,7 @@ export default {
 /**
  * Handle subdomain requests: foo.bennyhartnett.com → serve index.html
  * The SPA will detect the subdomain and load the correct page content
+ * Exception: nuclear.bennyhartnett.com → serve nuclear.html directly (standalone page)
  */
 async function handleSubdomain(request, url, hostname) {
   const subdomain = hostname.replace(`.${ROOT_DOMAIN}`, '');
@@ -69,6 +70,22 @@ async function handleSubdomain(request, url, hostname) {
     headers.set(INTERNAL_HEADER, '1');
 
     return fetch(assetUrl.toString(), {
+      method: request.method,
+      headers: headers,
+    });
+  }
+
+  // Nuclear subdomain: serve nuclear.html directly (it's a standalone page, not an SPA fragment)
+  if (subdomain === 'nuclear') {
+    const nuclearUrl = new URL(url);
+    nuclearUrl.hostname = ROOT_DOMAIN;
+    nuclearUrl.pathname = '/nuclear.html';
+    nuclearUrl.search = '';
+
+    const headers = new Headers(request.headers);
+    headers.set(INTERNAL_HEADER, '1');
+
+    return fetch(nuclearUrl.toString(), {
       method: request.method,
       headers: headers,
     });


### PR DESCRIPTION
The Cloudflare Worker now serves nuclear.html directly for nuclear.bennyhartnett.com instead of index.html. This eliminates the flash of unstyled content that occurred because the module script applying the gradient background ran asynchronously.