### PR TITLE
Remove header from resume second page

### DIFF
--- a/pages/resume.html
+++ b/pages/resume.html
@@ -53,8 +53,18 @@
           var viewport = page.getViewport({ scale: scale });
           var canvas = document.createElement('canvas');
           var context = canvas.getContext('2d');
-          canvas.height = viewport.height;
+
+          // Crop header from page 2 (remove top ~85 points at 612x792 PDF)
+          var cropTop = (pageNum === 2) ? Math.round(85 * scale) : 0;
+
           canvas.width = viewport.width;
+          canvas.height = viewport.height - cropTop;
+
+          // Shift rendering up to hide cropped area
+          if (cropTop > 0) {
+            context.translate(0, -cropTop);
+          }
+
           container.appendChild(canvas);
 
           return page.render({

--- a/sw.js
+++ b/sw.js
@@ -1,6 +1,6 @@
 // Service Worker for SWU Calculator PWA
 // Version must be updated when deploying new code to bust cache
-const CACHE_VERSION = 'v34';
+const CACHE_VERSION = 'v35';
 const CACHE_NAME = `swu-calculator-${CACHE_VERSION}`;
 
 // Files to cache for offline use


### PR DESCRIPTION
Crop the top ~85 points from page 2 when rendering the PDF to eliminate the redundant header that was creating excess whitespace between the merged pages.