### PR TITLE
Change return home text color to white

### DIFF
--- a/pages/thank-you.html
+++ b/pages/thank-you.html
@@ -54,6 +54,14 @@
   .home-btn:active {
     transform: translateY(0);
   }
+  a.home-btn,
+  a.home-btn:link,
+  a.home-btn:visited,
+  a.home-btn:hover,
+  a.home-btn:active,
+  a.home-btn:focus {
+    color: white;
+  }
 
   /* Dark mode scrollbar */
   ::-webkit-scrollbar {

--- a/sw.js
+++ b/sw.js
@@ -1,6 +1,6 @@
 // Service Worker for SWU Calculator PWA
 // Version must be updated when deploying new code to bust cache
-const CACHE_VERSION = 'v36';
+const CACHE_VERSION = 'v37';
 const CACHE_NAME = `swu-calculator-${CACHE_VERSION}`;
 
 // Files to cache for offline use


### PR DESCRIPTION
Add explicit CSS rules for all anchor states (:link, :visited, :hover, :active, :focus) to ensure the "Return Home" button text stays white and doesn't inherit default blue link colors.