### PR TITLE
Fix home link navigation on nuclear page

### DIFF
--- a/nuclear.html
+++ b/nuclear.html
@@ -671,7 +671,7 @@
     <header class="mb-6 flex flex-col items-center gap-3">
       <!-- Home link (hidden in standalone/installed mode) -->
       <a
-        href="/"
+        href="https://bennyhartnett.com/"
         class="standalone-hide absolute top-4 left-4 sm:top-6 sm:left-6 p-2 rounded-full bg-slate-200 dark:bg-slate-700 hover:bg-slate-300 dark:hover:bg-slate-600 transition-colors"
         aria-label="Go to home page"
       >

--- a/sw.js
+++ b/sw.js
@@ -1,6 +1,6 @@
 // Service Worker for SWU Calculator PWA
 // Version must be updated when deploying new code to bust cache
-const CACHE_VERSION = 'v36';
+const CACHE_VERSION = 'v37';
 const CACHE_NAME = `swu-calculator-${CACHE_VERSION}`;
 
 // Files to cache for offline use


### PR DESCRIPTION
Changed href from "/" to absolute URL "https://bennyhartnett.com/" so clicking home on nuclear.bennyhartnett.com correctly navigates to the main site.