### PR TITLE
Fix download loop and tab behavior

### DIFF
--- a/pages/resume-download.html
+++ b/pages/resume-download.html
@@ -56,9 +56,12 @@
     a.click();
     document.body.removeChild(a);
 
-    // Redirect back after download starts
+    // Close this tab/window after download starts (for new tab flow)
+    // If window.close() fails (not opened by script), redirect to resume page
     setTimeout(function() {
-      window.location.href = '/resume';
+      window.close();
+      // Fallback: redirect to full URL to avoid loop on same subdomain
+      window.location.href = 'https://resume.bennyhartnett.com';
     }, 500);
   }, 300);
 })();

--- a/pages/resume.html
+++ b/pages/resume.html
@@ -150,7 +150,7 @@
   }
 </style>
 <div class="pdf-container">
-  <a href="/resume-download" class="download-btn">
+  <a data-href="https://resume-download.bennyhartnett.com" data-external="true" class="download-btn">
     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
       <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path>
       <polyline points="7 10 12 15 17 10"></polyline>

--- a/sw.js
+++ b/sw.js
@@ -1,6 +1,6 @@
 // Service Worker for SWU Calculator PWA
 // Version must be updated when deploying new code to bust cache
-const CACHE_VERSION = 'v37';
+const CACHE_VERSION = 'v38';
 const CACHE_NAME = `swu-calculator-${CACHE_VERSION}`;
 
 // Files to cache for offline use


### PR DESCRIPTION
- Close tab/window after download instead of redirecting to /resume which caused infinite loop on same subdomain
- Download button on resume page now opens in new tab
- Fallback to full URL redirect if window.close() fails