### PR TITLE
Change link colors from blue to white

### DIFF
--- a/index.html
+++ b/index.html
@@ -620,7 +620,7 @@
 
 
     .content a {
-      color: #00bfff;
+      color: white;
       transition: color 0.3s ease;
     }
 

--- a/sw.js
+++ b/sw.js
@@ -1,6 +1,6 @@
 // Service Worker for SWU Calculator PWA
 // Version must be updated when deploying new code to bust cache
-const CACHE_VERSION = 'v40';
+const CACHE_VERSION = 'v41';
 const CACHE_NAME = `swu-calculator-${CACHE_VERSION}`;
 
 // Files to cache for offline use


### PR DESCRIPTION
Links inside .content were styled with #00bfff (blue) which was inconsistent with the site's design. Changed to white to match other link styles.