### PR TITLE
Fix auto-refresh and URL display bugs

### DIFF
--- a/manifest.webmanifest
+++ b/manifest.webmanifest
@@ -1,14 +1,15 @@
 {
   "name": "SWU Calculator",
   "short_name": "SWU Calc",
-  "version": "1.0.5",
-  "start_url": "/nuclear",
+  "version": "1.0.6",
+  "start_url": "https://nuclear.bennyhartnett.com/",
+  "scope": "https://nuclear.bennyhartnett.com/",
   "display": "standalone",
   "background_color": "#0f172a",
   "theme_color": "#0f172a",
   "icons": [
     {
-      "src": "/centrus_icon.png",
+      "src": "https://bennyhartnett.com/centrus_icon.png",
       "sizes": "512x512",
       "type": "image/png"
     }

--- a/nuclear.html
+++ b/nuclear.html
@@ -1854,30 +1854,18 @@
     if ('serviceWorker' in navigator) {
       window.addEventListener('load', () => {
         navigator.serviceWorker.register('/sw.js').then((registration) => {
-          // Check for updates on page load
-          registration.update();
-
-          // Listen for new service worker installing
+          // Listen for new service worker installing (browser handles update checks automatically)
           registration.addEventListener('updatefound', () => {
             const newWorker = registration.installing;
             newWorker.addEventListener('statechange', () => {
               if (newWorker.state === 'installed' && navigator.serviceWorker.controller) {
-                // New version available - activate it immediately
-                newWorker.postMessage('skipWaiting');
+                // New version available - show a subtle notification instead of auto-reloading
+                console.log('New version available. Refresh to update.');
               }
             });
           });
         }).catch((error) => {
           console.error('Service Worker registration failed:', error);
-        });
-
-        // Reload page when new service worker takes over
-        let refreshing = false;
-        navigator.serviceWorker.addEventListener('controllerchange', () => {
-          if (!refreshing) {
-            refreshing = true;
-            window.location.reload();
-          }
         });
       });
     }

--- a/sw.js
+++ b/sw.js
@@ -1,6 +1,6 @@
 // Service Worker for SWU Calculator PWA
 // Version must be updated when deploying new code to bust cache
-const CACHE_VERSION = 'v41';
+const CACHE_VERSION = 'v42';
 const CACHE_NAME = `swu-calculator-${CACHE_VERSION}`;
 
 // Files to cache for offline use


### PR DESCRIPTION
- Remove aggressive service worker update forcing on every page load
- Remove automatic reload on controllerchange that caused refresh loops
- Update manifest with proper subdomain scope and start_url for iOS PWA
- Increment cache version to v42