### PR TITLE
Fix resume download filename with name and date

### DIFF
--- a/pages/resume-download.html
+++ b/pages/resume-download.html
@@ -48,10 +48,15 @@
     var p = ['/', 'assets', '/d/', 'r-', '8f3a', '2c9e', '7b1d', '.pdf'];
     var url = p[0] + p[1] + p[2] + p[3] + p[4] + p[5] + p[6] + p[7];
 
-    // Create download link
+    // Create download link with dynamic filename
+    var months = ['January', 'February', 'March', 'April', 'May', 'June',
+                  'July', 'August', 'September', 'October', 'November', 'December'];
+    var now = new Date();
+    var filename = 'Benny Hartnett - ' + months[now.getMonth()] + ' ' + now.getFullYear() + '.pdf';
+
     var a = document.createElement('a');
     a.href = url;
-    a.download = 'resume_benny_hartnett.pdf';
+    a.download = filename;
     document.body.appendChild(a);
     a.click();
     document.body.removeChild(a);

--- a/sw.js
+++ b/sw.js
@@ -1,6 +1,6 @@
 // Service Worker for SWU Calculator PWA
 // Version must be updated when deploying new code to bust cache
-const CACHE_VERSION = 'v41';
+const CACHE_VERSION = 'v42';
 const CACHE_NAME = `swu-calculator-${CACHE_VERSION}`;
 
 // Files to cache for offline use


### PR DESCRIPTION
The resume download now saves as "Benny Hartnett - [Month] [Year].pdf" instead of "untitled" in Chrome's PDF viewer.