### PR TITLE
Fix resume page 3js background display

### DIFF
--- a/pages/resume.html
+++ b/pages/resume.html
@@ -3,7 +3,8 @@
     margin: 0;
     overflow-x: hidden;
     overflow-y: auto;
-    background: #525659;
+    /* Transparent to show Three.js wave background from index.html */
+    background: transparent;
   }
   .pdf-container {
     display: flex;

--- a/sw.js
+++ b/sw.js
@@ -1,6 +1,6 @@
 // Service Worker for SWU Calculator PWA
 // Version must be updated when deploying new code to bust cache
-const CACHE_VERSION = 'v42';
+const CACHE_VERSION = 'v43';
 const CACHE_NAME = `swu-calculator-${CACHE_VERSION}`;
 
 // Files to cache for offline use


### PR DESCRIPTION
The resume page was setting body background to grey (#525659) which covered the Three.js wave canvas. Changed to transparent to allow the animated background to show through.