### PR TITLE
Add domain alias for nuclear subdomain

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -1,6 +1,6 @@
 // Service Worker for SWU Calculator PWA
 // Version must be updated when deploying new code to bust cache
-const CACHE_VERSION = 'v42';
+const CACHE_VERSION = 'v43';
 const CACHE_NAME = `swu-calculator-${CACHE_VERSION}`;
 
 // Files to cache for offline use

--- a/workers/router.js
+++ b/workers/router.js
@@ -80,8 +80,8 @@ async function handleSubdomain(request, url, hostname) {
     return Response.redirect(`https://sent.${ROOT_DOMAIN}/`, 301);
   }
 
-  // Nuclear subdomain: serve nuclear.html directly (it's a standalone page, not an SPA fragment)
-  if (subdomain === 'nuclear') {
+  // Nuclear subdomain (and centrus alias): serve nuclear.html directly (it's a standalone page, not an SPA fragment)
+  if (subdomain === 'nuclear' || subdomain === 'centrus') {
     const nuclearUrl = new URL(url);
     nuclearUrl.hostname = ROOT_DOMAIN;
     nuclearUrl.pathname = '/nuclear.html';


### PR DESCRIPTION
Both centrus and nuclear subdomains now serve nuclear.html directly without any URL redirect, allowing access via either domain.