### PR TITLE
Fix download endpoint returning 404 error

### DIFF
--- a/pages/download.html
+++ b/pages/download.html
@@ -1,0 +1,73 @@
+<style>
+  body {
+    font-family: 'Inter', sans-serif;
+    color: white;
+    margin: 0;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    min-height: calc(100vh - 56px);
+  }
+  .loading {
+    text-align: center;
+  }
+  .loading p {
+    margin-top: 1rem;
+    opacity: 0.7;
+  }
+  .spinner {
+    width: 40px;
+    height: 40px;
+    border: 3px solid rgba(255,255,255,0.2);
+    border-top-color: var(--wave-color, #4a9eff);
+    border-radius: 50%;
+    animation: spin 1s linear infinite;
+    margin: 0 auto;
+  }
+  @keyframes spin {
+    to { transform: rotate(360deg); }
+  }
+  noscript {
+    text-align: center;
+    display: block;
+  }
+</style>
+<div class="loading">
+  <div class="spinner"></div>
+  <p>Preparing download...</p>
+</div>
+<noscript>
+  <p>JavaScript is required to download this file.</p>
+  <p><a href="/" style="color: var(--wave-color, #4a9eff);">Return to homepage</a></p>
+</noscript>
+<script>
+(function() {
+  // Delay to prevent automated scraping
+  setTimeout(function() {
+    // Construct URL at runtime to avoid static scraping
+    var p = ['/', 'assets', '/d/', 'r-', '8f3a', '2c9e', '7b1d', '.pdf'];
+    var url = p[0] + p[1] + p[2] + p[3] + p[4] + p[5] + p[6] + p[7];
+
+    // Create download link with dynamic filename
+    var months = ['January', 'February', 'March', 'April', 'May', 'June',
+                  'July', 'August', 'September', 'October', 'November', 'December'];
+    var now = new Date();
+    var filename = 'Benny Hartnett - ' + months[now.getMonth()] + ' ' + now.getFullYear() + '.pdf';
+
+    var a = document.createElement('a');
+    a.href = url;
+    a.download = filename;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+
+    // Close this tab/window after download starts (for new tab flow)
+    // If window.close() fails (not opened by script), redirect to resume page
+    setTimeout(function() {
+      window.close();
+      // Fallback: redirect to full URL to avoid loop on same subdomain
+      window.location.href = 'https://resume.bennyhartnett.com';
+    }, 500);
+  }, 300);
+})();
+</script>

--- a/sw.js
+++ b/sw.js
@@ -1,6 +1,6 @@
 // Service Worker for SWU Calculator PWA
 // Version must be updated when deploying new code to bust cache
-const CACHE_VERSION = 'v43';
+const CACHE_VERSION = 'v44';
 const CACHE_NAME = `swu-calculator-${CACHE_VERSION}`;
 
 // Files to cache for offline use


### PR DESCRIPTION
Add pages/download.html to serve resume download when accessing download.bennyhartnett.com subdomain. The SPA was looking for this file but only resume-download.html existed.