### PR TITLE
Fix HTTPS redirect loop on sent subdomain

### DIFF
--- a/pages/sent.html
+++ b/pages/sent.html
@@ -96,7 +96,7 @@
     <h1>Thank You!</h1>
     <p>Your message has been sent successfully. I'll get back to you as soon as possible.</p>
     <p class="countdown">Redirecting to home in <span id="countdown">5</span> seconds...</p>
-    <a href="/" class="home-btn">Return Home</a>
+    <a href="https://bennyhartnett.com" class="home-btn">Return Home</a>
   </div>
 </div>
 <script>
@@ -111,7 +111,7 @@
       }
       if (seconds <= 0) {
         clearInterval(timer);
-        window.location.href = '/';
+        window.location.href = 'https://bennyhartnett.com';
       }
     }, 1000);
   })();

--- a/sw.js
+++ b/sw.js
@@ -1,6 +1,6 @@
 // Service Worker for SWU Calculator PWA
 // Version must be updated when deploying new code to bust cache
-const CACHE_VERSION = 'v43';
+const CACHE_VERSION = 'v44';
 const CACHE_NAME = `swu-calculator-${CACHE_VERSION}`;
 
 // Files to cache for offline use


### PR DESCRIPTION
The sent page was redirecting to '/' which on the subdomain just reloads the same page, creating an infinite loop. Changed the redirect to use the absolute URL https://bennyhartnett.com instead.