### PR TITLE
Fix URL display at top of iPhone app

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,6 +29,8 @@
   <link rel="icon" type="image/svg+xml" href="https://unpkg.com/heroicons@2.0.18/24/solid/code-bracket.svg" />
   <meta name="robots" content="index,follow" />
   <meta name="theme-color" content="#0D6EFD" />
+  <meta name="apple-mobile-web-app-capable" content="yes" />
+  <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
   <link rel="apple-touch-icon" href="https://unpkg.com/heroicons@2.0.18/24/solid/code-bracket.svg" />
 
   <!-- Identity Proofing (rel="me") -->

--- a/sw.js
+++ b/sw.js
@@ -1,6 +1,6 @@
 // Service Worker for SWU Calculator PWA
 // Version must be updated when deploying new code to bust cache
-const CACHE_VERSION = 'v44';
+const CACHE_VERSION = 'v45';
 const CACHE_NAME = `swu-calculator-${CACHE_VERSION}`;
 
 // Files to cache for offline use


### PR DESCRIPTION
The index.html was missing apple-mobile-web-app-capable and apple-mobile-web-app-status-bar-style meta tags, causing iOS Safari to show the URL bar when the site is added to home screen.