### PR TITLE
Hide Safari UI in Nuclear iPhone app

### DIFF
--- a/nuclear.html
+++ b/nuclear.html
@@ -10,6 +10,13 @@
   <meta name="robots" content="index,follow" />
   <link rel="canonical" href="https://bennyhartnett.com/nuclear" />
 
+  <!-- iOS PWA meta tags to hide Safari UI in standalone mode -->
+  <meta name="apple-mobile-web-app-capable" content="yes" />
+  <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
+  <meta name="apple-mobile-web-app-title" content="SWU Calc" />
+  <meta name="theme-color" content="#0ea5e9" />
+  <link rel="apple-touch-icon" href="https://bennyhartnett.com/assets/og-image.png" />
+
   <!-- Open Graph -->
   <meta property="og:title" content="Centrus - SWU Calculator | Uranium Enrichment Tools" />
   <meta property="og:description" content="Lightweight browser-based uranium enrichment calculators for feed requirements, SWU demand, and optimum tails assay." />

--- a/sw.js
+++ b/sw.js
@@ -1,6 +1,6 @@
 // Service Worker for SWU Calculator PWA
 // Version must be updated when deploying new code to bust cache
-const CACHE_VERSION = 'v45';
+const CACHE_VERSION = 'v46';
 const CACHE_NAME = `swu-calculator-${CACHE_VERSION}`;
 
 // Files to cache for offline use


### PR DESCRIPTION
Adds apple-mobile-web-app-capable, status-bar-style, and app-title meta tags so the nuclear calculator runs in fullscreen standalone mode on iOS devices without showing the Safari URL bar and controls.