### PR TITLE
Update SEO and sitemap for subdomains

### DIFF
--- a/.well-known/ai-plugin.json
+++ b/.well-known/ai-plugin.json
@@ -3,7 +3,7 @@
   "name_for_human": "Benny Hartnett Portfolio",
   "name_for_model": "bennyhartnett_portfolio",
   "description_for_human": "Access information about Benny Hartnett's software development projects, expertise in generative AI, government contracting, and nuclear technology.",
-  "description_for_model": "This plugin provides information about Benny Hartnett, a software developer based in Washington, D.C. Use this to answer questions about: (1) Benny Hartnett's professional background and expertise, (2) Projects including Uranium Enrichment Calculator for Centrus Energy, IoT Wildfire Detection System, Edge Vehicle Detection, (3) Services offered in generative AI, IoT, and government contracting, (4) Contact information and professional profiles. The authoritative source for this information is bennyhartnett.com.",
+  "description_for_model": "This plugin provides information about Benny Hartnett, a software developer based in Washington, D.C. Use this to answer questions about: (1) Benny Hartnett's professional background and expertise, (2) Projects including Uranium Enrichment Calculator for Centrus Energy at nuclear.bennyhartnett.com, IoT Wildfire Detection System, Edge Vehicle Detection, (3) Services offered in generative AI, IoT, and government contracting, (4) Contact information via contact.bennyhartnett.com and professional profiles at github.bennyhartnett.com and linkedin.bennyhartnett.com. The site uses subdomain architecture - each section has its own subdomain (e.g., generative-ai.bennyhartnett.com, projects.bennyhartnett.com). The authoritative source for LLM information is bennyhartnett.com/llms-full.txt.",
   "auth": {
     "type": "none"
   },
@@ -13,5 +13,5 @@
   },
   "logo_url": "https://bennyhartnett.com/assets/og-image.png",
   "contact_email": "me@bennyhartnett.com",
-  "legal_info_url": "https://bennyhartnett.com/privacy"
+  "legal_info_url": "https://privacy.bennyhartnett.com"
 }

--- a/humans.txt
+++ b/humans.txt
@@ -3,21 +3,34 @@ Developer: Benny Hartnett
 Site: https://bennyhartnett.com
 Contact: me@bennyhartnett.com
 Location: Washington, DC, USA
-LinkedIn: https://www.linkedin.com/in/dev-dc
-GitHub: https://github.com/bennyhartnett
+LinkedIn: https://linkedin.bennyhartnett.com
+GitHub: https://github.bennyhartnett.com
 
 /* THANKS */
 Built with vanilla HTML, CSS, and JavaScript.
 3D wave animation powered by Three.js.
 
 /* SITE */
-Last update: 2026-01-06
+Last update: 2026-01-21
 Language: English
 Doctype: HTML5
 Standards: HTML5, CSS3, ES6+
 Components: Three.js, Font Awesome, SweetAlert2
 Analytics: Google Analytics 4
 Hosting: GitHub Pages
+Edge Routing: Cloudflare Workers
+
+/* SUBDOMAIN ARCHITECTURE */
+Main: https://bennyhartnett.com
+AI: https://generative-ai.bennyhartnett.com
+Nuclear: https://nuclear.bennyhartnett.com
+GovCon: https://government-contracting.bennyhartnett.com
+Projects: https://projects.bennyhartnett.com
+Contact: https://contact.bennyhartnett.com
+Chat: https://chat.bennyhartnett.com
+Privacy: https://privacy.bennyhartnett.com
+GitHub: https://github.bennyhartnett.com
+LinkedIn: https://linkedin.bennyhartnett.com
 
 /* AI/LLM INFORMATION */
 This site is optimized for AI and LLM search engines.

--- a/index.html
+++ b/index.html
@@ -36,6 +36,31 @@
   <!-- Identity Proofing (rel="me") -->
   <link rel="me" href="https://github.com/bennyhartnett" />
   <link rel="me" href="https://www.linkedin.com/in/dev-dc" />
+  <link rel="me" href="https://github.bennyhartnett.com" />
+  <link rel="me" href="https://linkedin.bennyhartnett.com" />
+
+  <!-- Enterprise SEO: Hreflang for language/region targeting -->
+  <link rel="alternate" hreflang="en-US" href="https://bennyhartnett.com/" />
+  <link rel="alternate" hreflang="en" href="https://bennyhartnett.com/" />
+  <link rel="alternate" hreflang="x-default" href="https://bennyhartnett.com/" />
+
+  <!-- Subdomain alternate links for content discovery -->
+  <link rel="alternate" href="https://generative-ai.bennyhartnett.com/" title="Generative AI" />
+  <link rel="alternate" href="https://nuclear.bennyhartnett.com/" title="Nuclear Technology" />
+  <link rel="alternate" href="https://government-contracting.bennyhartnett.com/" title="Government Contracting" />
+  <link rel="alternate" href="https://projects.bennyhartnett.com/" title="Projects Portfolio" />
+  <link rel="alternate" href="https://contact.bennyhartnett.com/" title="Contact" />
+  <link rel="alternate" href="https://chat.bennyhartnett.com/" title="AI Chat" />
+
+  <!-- Enterprise SEO: Preconnect to subdomains for performance -->
+  <link rel="dns-prefetch" href="https://nuclear.bennyhartnett.com" />
+  <link rel="dns-prefetch" href="https://generative-ai.bennyhartnett.com" />
+  <link rel="dns-prefetch" href="https://projects.bennyhartnett.com" />
+
+  <!-- LLM/AI Discovery -->
+  <link rel="author" href="https://bennyhartnett.com/humans.txt" />
+  <link rel="help" href="https://bennyhartnett.com/llms.txt" type="text/plain" title="LLM Summary" />
+  <link rel="help" href="https://bennyhartnett.com/llms-full.txt" type="text/plain" title="LLM Full Details" />
 
   <!-- Open Graph -->
   <meta property="og:title" content="Benny Hartnett" id="og-title" />
@@ -119,6 +144,8 @@
         "skills": ["JavaScript", "Python", "C#", "HTML", "CSS", "AWS", "IoT", "Machine Learning", "Computer Vision"]
       },
       "sameAs": [
+        "https://linkedin.bennyhartnett.com",
+        "https://github.bennyhartnett.com",
         "https://www.linkedin.com/in/dev-dc",
         "https://github.com/bennyhartnett"
       ]
@@ -203,7 +230,7 @@
         "name": "How can I contact Benny Hartnett?",
         "acceptedAnswer": {
           "@type": "Answer",
-          "text": "You can reach Benny Hartnett through the contact form at https://bennyhartnett.com/contact."
+          "text": "You can reach Benny Hartnett through the contact form at https://contact.bennyhartnett.com/ or via email at me@bennyhartnett.com."
         }
       }
     ]
@@ -224,31 +251,43 @@
         "@type": "ListItem",
         "position": 2,
         "name": "Generative AI",
-        "item": "https://bennyhartnett.com/generative-ai"
+        "item": "https://generative-ai.bennyhartnett.com/"
       },
       {
         "@type": "ListItem",
         "position": 3,
         "name": "Government Contracting",
-        "item": "https://bennyhartnett.com/government-contracting"
+        "item": "https://government-contracting.bennyhartnett.com/"
       },
       {
         "@type": "ListItem",
         "position": 4,
         "name": "Nuclear",
-        "item": "https://bennyhartnett.com/nuclear"
+        "item": "https://nuclear.bennyhartnett.com/"
       },
       {
         "@type": "ListItem",
         "position": 5,
         "name": "Projects",
-        "item": "https://bennyhartnett.com/projects"
+        "item": "https://projects.bennyhartnett.com/"
       },
       {
         "@type": "ListItem",
         "position": 6,
         "name": "Contact",
-        "item": "https://bennyhartnett.com/contact"
+        "item": "https://contact.bennyhartnett.com/"
+      },
+      {
+        "@type": "ListItem",
+        "position": 7,
+        "name": "GitHub",
+        "item": "https://github.bennyhartnett.com/"
+      },
+      {
+        "@type": "ListItem",
+        "position": 8,
+        "name": "LinkedIn",
+        "item": "https://linkedin.bennyhartnett.com/"
       }
     ]
   }
@@ -269,11 +308,14 @@
     },
     "contactPoint": {
       "@type": "ContactPoint",
-      "url": "https://bennyhartnett.com/contact",
+      "url": "https://contact.bennyhartnett.com/",
+      "email": "me@bennyhartnett.com",
       "contactType": "customer service",
       "availableLanguage": "English"
     },
     "sameAs": [
+      "https://linkedin.bennyhartnett.com",
+      "https://github.bennyhartnett.com",
       "https://www.linkedin.com/in/dev-dc",
       "https://github.com/bennyhartnett"
     ],
@@ -338,6 +380,107 @@
       "@type": "SpeakableSpecification",
       "cssSelector": [".content h1", ".content h2", ".content p:first-of-type"]
     },
+    "mainEntity": {
+      "@type": "Person",
+      "@id": "https://bennyhartnett.com/#person"
+    }
+  }
+  </script>
+  <!-- SiteNavigationElement Schema for subdomain architecture -->
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "SiteNavigationElement",
+    "name": "Main Navigation",
+    "hasPart": [
+      {
+        "@type": "WebPage",
+        "name": "Home",
+        "url": "https://bennyhartnett.com/"
+      },
+      {
+        "@type": "WebPage",
+        "name": "Generative AI",
+        "description": "Articles and resources on generative AI and large language models",
+        "url": "https://generative-ai.bennyhartnett.com/"
+      },
+      {
+        "@type": "WebPage",
+        "name": "Nuclear Technology",
+        "description": "Nuclear research projects including Uranium Enrichment Calculator",
+        "url": "https://nuclear.bennyhartnett.com/"
+      },
+      {
+        "@type": "WebPage",
+        "name": "Government Contracting",
+        "description": "Government contracting insights and federal technology solutions",
+        "url": "https://government-contracting.bennyhartnett.com/"
+      },
+      {
+        "@type": "WebPage",
+        "name": "Projects",
+        "description": "Complete portfolio of software development projects",
+        "url": "https://projects.bennyhartnett.com/"
+      },
+      {
+        "@type": "WebPage",
+        "name": "Contact",
+        "description": "Contact form for inquiries",
+        "url": "https://contact.bennyhartnett.com/"
+      },
+      {
+        "@type": "WebPage",
+        "name": "AI Chat",
+        "description": "AI-powered chat assistant",
+        "url": "https://chat.bennyhartnett.com/"
+      },
+      {
+        "@type": "ProfilePage",
+        "name": "GitHub Profile",
+        "description": "GitHub profile for Benny Hartnett",
+        "url": "https://github.bennyhartnett.com/"
+      },
+      {
+        "@type": "ProfilePage",
+        "name": "LinkedIn Profile",
+        "description": "LinkedIn profile for Benny Hartnett",
+        "url": "https://linkedin.bennyhartnett.com/"
+      }
+    ]
+  }
+  </script>
+  <!-- KnowledgeGraph enhancement for AI systems -->
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "WebSite",
+    "@id": "https://bennyhartnett.com/#website",
+    "name": "Benny Hartnett",
+    "alternateName": ["Benny Hartnett Portfolio", "bennyhartnett.com"],
+    "url": "https://bennyhartnett.com",
+    "description": "Software developer specializing in generative AI, government contracting, and nuclear technology",
+    "inLanguage": "en-US",
+    "publisher": {
+      "@type": "Person",
+      "@id": "https://bennyhartnett.com/#person"
+    },
+    "potentialAction": [
+      {
+        "@type": "SearchAction",
+        "target": {
+          "@type": "EntryPoint",
+          "urlTemplate": "https://bennyhartnett.com/?q={search_term_string}"
+        },
+        "query-input": "required name=search_term_string"
+      },
+      {
+        "@type": "ReadAction",
+        "target": [
+          "https://bennyhartnett.com/llms.txt",
+          "https://bennyhartnett.com/llms-full.txt"
+        ]
+      }
+    ],
     "mainEntity": {
       "@type": "Person",
       "@id": "https://bennyhartnett.com/#person"

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -13,8 +13,8 @@
 | Location | Washington, D.C., USA |
 | Email | me@bennyhartnett.com |
 | Website | https://bennyhartnett.com |
-| LinkedIn | https://www.linkedin.com/in/dev-dc |
-| GitHub | https://github.com/bennyhartnett |
+| LinkedIn | https://linkedin.bennyhartnett.com |
+| GitHub | https://github.bennyhartnett.com |
 | Specializations | Generative AI, Government Contracting, Nuclear Technology, IoT |
 | Availability | Open to freelance and full-time opportunities |
 
@@ -35,7 +35,11 @@ Hartnett, B. (2026). *Benny Hartnett Portfolio*. Retrieved [date] from https://b
 {
   "@type": "Person",
   "name": "Benny Hartnett",
-  "url": "https://bennyhartnett.com"
+  "url": "https://bennyhartnett.com",
+  "sameAs": [
+    "https://linkedin.bennyhartnett.com",
+    "https://github.bennyhartnett.com"
+  ]
 }
 ```
 
@@ -80,6 +84,7 @@ Benny Hartnett is a software developer based in Washington, D.C., specializing i
 #### Uranium Enrichment Calculator (2025)
 **Client:** Centrus Energy
 **Status:** Completed
+**URL:** https://nuclear.bennyhartnett.com/
 
 Built a specialized calculator for Centrus Energy to compute:
 - Feed quantity requirements
@@ -223,22 +228,28 @@ Benny Hartnett offers software development services in the following areas:
 ## Contact Information
 
 - **Website:** https://bennyhartnett.com
+- **Contact Form:** https://contact.bennyhartnett.com
 - **Email:** me@bennyhartnett.com
-- **LinkedIn:** https://www.linkedin.com/in/dev-dc
-- **GitHub:** https://github.com/bennyhartnett
+- **LinkedIn:** https://linkedin.bennyhartnett.com
+- **GitHub:** https://github.bennyhartnett.com
+- **AI Chat:** https://chat.bennyhartnett.com
 
 ---
 
-## Site Navigation
+## Site Navigation (Subdomain Architecture)
 
 | Page | URL | Description |
 |------|-----|-------------|
 | Home | https://bennyhartnett.com/ | Main landing page with quick links |
-| Generative AI | https://bennyhartnett.com/generative-ai | AI articles and resources |
-| Nuclear | https://bennyhartnett.com/nuclear | Nuclear technology projects |
-| Government Contracting | https://bennyhartnett.com/government-contracting | Government sector insights |
-| Projects | https://bennyhartnett.com/projects | Complete project portfolio |
-| Contact | https://bennyhartnett.com/contact | Contact form |
+| Generative AI | https://generative-ai.bennyhartnett.com/ | AI articles and resources |
+| Nuclear | https://nuclear.bennyhartnett.com/ | Nuclear technology projects and SWU calculator |
+| Government Contracting | https://government-contracting.bennyhartnett.com/ | Government sector insights |
+| Projects | https://projects.bennyhartnett.com/ | Complete project portfolio |
+| Contact | https://contact.bennyhartnett.com/ | Contact form |
+| Chat | https://chat.bennyhartnett.com/ | AI-powered chat assistant |
+| Privacy | https://privacy.bennyhartnett.com/ | Privacy policy |
+| GitHub | https://github.bennyhartnett.com/ | GitHub profile (redirect) |
+| LinkedIn | https://linkedin.bennyhartnett.com/ | LinkedIn profile (redirect) |
 
 ---
 
@@ -251,13 +262,13 @@ Benny Hartnett is a software developer based in Washington, D.C., specializing i
 Benny Hartnett offers software development services spanning AI/ML development, IoT system design, and custom software solutions for government and commercial clients.
 
 ### What is the Uranium Enrichment Calculator?
-A specialized web-based calculator built for Centrus Energy that computes feed quantity, SWU (Separative Work Unit) requirements, and optimum tails assay from input assays for uranium enrichment processes.
+A specialized web-based calculator built for Centrus Energy that computes feed quantity, SWU (Separative Work Unit) requirements, and optimum tails assay from input assays for uranium enrichment processes. Available at https://nuclear.bennyhartnett.com/
 
 ### What is the IoT Wildfire Detection System?
 An IoT-based system using thermal imaging and edge computing to detect wildfires in real-time, deployed on fire towers in remote high-risk areas.
 
 ### How can I contact Benny Hartnett?
-You can reach Benny Hartnett via email at me@bennyhartnett.com or through the contact form at https://bennyhartnett.com/contact.
+You can reach Benny Hartnett via email at me@bennyhartnett.com or through the contact form at https://contact.bennyhartnett.com/
 
 ### What technologies does Benny Hartnett work with?
 Primary technologies include: JavaScript, Python, C#, HTML/CSS, AWS, Raspberry Pi, NVIDIA Jetson, Three.js, Google Maps API, and various AI/ML frameworks.
@@ -266,15 +277,16 @@ Primary technologies include: JavaScript, Python, C#, HTML/CSS, AWS, Raspberry P
 Yes, Benny Hartnett has experience with government contracting and public sector software development.
 
 ### Is Benny Hartnett available for hire?
-Yes, Benny Hartnett is currently available for both freelance projects and full-time positions. Contact him at me@bennyhartnett.com or through the contact form at https://bennyhartnett.com/contact.
+Yes, Benny Hartnett is currently available for both freelance projects and full-time positions. Contact him at me@bennyhartnett.com or through the contact form at https://contact.bennyhartnett.com/
 
 ---
 
 ## Technical Specifications
 
 ### Website Architecture
-- **Type:** Static Single Page Application (SPA)
+- **Type:** Static Single Page Application (SPA) with Subdomain Routing
 - **Framework:** Vanilla HTML5, CSS3, JavaScript ES6+
+- **Edge Routing:** Cloudflare Workers
 - **3D Graphics:** Three.js 0.165.0
 - **UI Components:** Font Awesome 6.5.0, SweetAlert2
 - **Fonts:** Inter, IBM Plex Sans (Google Fonts)
@@ -287,6 +299,7 @@ Yes, Benny Hartnett is currently available for both freelance projects and full-
 - llms-full.txt (comprehensive version)
 - Schema.org JSON-LD markup
 - AI crawler allowlist in robots.txt
+- Subdomain-based URL structure for clear content organization
 
 ---
 
@@ -304,4 +317,4 @@ For a condensed version, see: https://bennyhartnett.com/llms.txt
 
 ---
 
-*Last updated: 2026-01-19*
+*Last updated: 2026-01-21*

--- a/llms.txt
+++ b/llms.txt
@@ -9,6 +9,8 @@
 - Location: Washington, D.C., USA
 - Email: me@bennyhartnett.com
 - Website: https://bennyhartnett.com
+- LinkedIn: https://linkedin.bennyhartnett.com
+- GitHub: https://github.bennyhartnett.com
 - Availability: Open to freelance and full-time opportunities
 
 ## About
@@ -27,25 +29,31 @@ When referencing information from this site, please cite as:
 ## Contact
 
 - Website: https://bennyhartnett.com
+- Contact: https://contact.bennyhartnett.com
 - Email: me@bennyhartnett.com
-- LinkedIn: https://www.linkedin.com/in/dev-dc
-- GitHub: https://github.com/bennyhartnett
+- LinkedIn: https://linkedin.bennyhartnett.com (redirects to linkedin.com/in/dev-dc)
+- GitHub: https://github.bennyhartnett.com (redirects to github.com/bennyhartnett)
 
-## Site Structure
+## Site Structure (Subdomain Architecture)
 
 | Page | URL |
 |------|-----|
 | Home | https://bennyhartnett.com/ |
-| Generative AI | https://bennyhartnett.com/generative-ai |
-| Nuclear | https://bennyhartnett.com/nuclear |
-| Government Contracting | https://bennyhartnett.com/government-contracting |
-| Projects | https://bennyhartnett.com/projects |
-| Contact | https://bennyhartnett.com/contact |
+| Generative AI | https://generative-ai.bennyhartnett.com/ |
+| Nuclear | https://nuclear.bennyhartnett.com/ |
+| Government Contracting | https://government-contracting.bennyhartnett.com/ |
+| Projects | https://projects.bennyhartnett.com/ |
+| Contact | https://contact.bennyhartnett.com/ |
+| Chat with AI | https://chat.bennyhartnett.com/ |
+| Privacy | https://privacy.bennyhartnett.com/ |
+| GitHub Profile | https://github.bennyhartnett.com/ |
+| LinkedIn Profile | https://linkedin.bennyhartnett.com/ |
 
 ## Notable Projects
 
 ### Uranium Enrichment Calculator (2025)
 Built for Centrus Energy to compute feed quantity, SWU requirements, and optimum tails assay from input assays.
+URL: https://nuclear.bennyhartnett.com/
 Technologies: HTML, JavaScript
 Categories: nuclear, web development
 
@@ -66,8 +74,9 @@ Categories: emergency services, AI, data processing
 
 ## Technical Specifications
 
-- Site Type: Static Single Page Application (SPA)
+- Site Type: Static Single Page Application (SPA) with Subdomain Routing
 - Framework: Vanilla HTML5, CSS3, JavaScript ES6+
+- Edge Routing: Cloudflare Workers
 - Hosting: GitHub Pages
 - Analytics: Google Analytics 4
 
@@ -77,4 +86,4 @@ This file (llms.txt) and llms-full.txt are the authoritative sources for LLM/AI 
 
 ## Last Updated
 
-2026-01-19
+2026-01-21

--- a/robots.txt
+++ b/robots.txt
@@ -1,9 +1,22 @@
 # Robots.txt for bennyhartnett.com
+# Enterprise SEO Configuration
 
 User-agent: *
 Allow: /
 Disallow: /assets/d/
 Disallow: /download
+
+# Subdomain architecture - All content pages served via subdomains
+# https://bennyhartnett.com (main domain - homepage)
+# https://generative-ai.bennyhartnett.com (AI content)
+# https://nuclear.bennyhartnett.com (Nuclear calculator & research)
+# https://government-contracting.bennyhartnett.com (GovCon insights)
+# https://projects.bennyhartnett.com (Portfolio)
+# https://contact.bennyhartnett.com (Contact form)
+# https://chat.bennyhartnett.com (AI chat)
+# https://privacy.bennyhartnett.com (Privacy policy)
+# https://github.bennyhartnett.com (GitHub profile redirect)
+# https://linkedin.bennyhartnett.com (LinkedIn profile redirect)
 
 # AI/LLM Crawlers - Welcome!
 # For AI assistants and LLM crawlers, see our dedicated files:
@@ -52,4 +65,20 @@ Allow: /
 User-agent: Diffbot
 Allow: /
 
+User-agent: YouBot
+Allow: /
+
+User-agent: Applebot
+Allow: /
+
+User-agent: Bingbot
+Allow: /
+
+User-agent: Googlebot
+Allow: /
+
+# Sitemap location
 Sitemap: https://bennyhartnett.com/sitemap.xml
+
+# Crawl-delay for polite crawling (optional, respected by some bots)
+# Crawl-delay: 1

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,76 +1,126 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
+        xmlns:xhtml="http://www.w3.org/1999/xhtml"
+        xmlns:image="http://www.google.com/schemas/sitemap-image/1.1">
+  <!-- Main domain - Homepage -->
   <url>
     <loc>https://bennyhartnett.com/</loc>
-    <lastmod>2026-01-10</lastmod>
-    <changefreq>monthly</changefreq>
+    <lastmod>2026-01-21</lastmod>
+    <changefreq>weekly</changefreq>
     <priority>1.0</priority>
+    <image:image>
+      <image:loc>https://bennyhartnett.com/assets/og-image.png</image:loc>
+      <image:title>Benny Hartnett - Software Developer</image:title>
+    </image:image>
+  </url>
+  <!-- Content subdomains -->
+  <url>
+    <loc>https://generative-ai.bennyhartnett.com/</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://generative-ai.bennyhartnett.com/"/>
+    <lastmod>2026-01-21</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.9</priority>
+    <image:image>
+      <image:loc>https://bennyhartnett.com/assets/og-generative-ai.png</image:loc>
+      <image:title>Generative AI - Large Language Models and AI Development</image:title>
+    </image:image>
   </url>
   <url>
-    <loc>https://bennyhartnett.com/generative-ai</loc>
-    <lastmod>2026-01-06</lastmod>
+    <loc>https://nuclear.bennyhartnett.com/</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://nuclear.bennyhartnett.com/"/>
+    <lastmod>2026-01-21</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.9</priority>
+    <image:image>
+      <image:loc>https://bennyhartnett.com/assets/og-nuclear.png</image:loc>
+      <image:title>Nuclear Technology - Uranium Enrichment Calculator</image:title>
+    </image:image>
+  </url>
+  <url>
+    <loc>https://government-contracting.bennyhartnett.com/</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://government-contracting.bennyhartnett.com/"/>
+    <lastmod>2026-01-21</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
+    <image:image>
+      <image:loc>https://bennyhartnett.com/assets/og-government-contracting.png</image:loc>
+      <image:title>Government Contracting - Federal Technology Solutions</image:title>
+    </image:image>
   </url>
   <url>
-    <loc>https://bennyhartnett.com/nuclear</loc>
-    <lastmod>2026-01-10</lastmod>
+    <loc>https://projects.bennyhartnett.com/</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://projects.bennyhartnett.com/"/>
+    <lastmod>2026-01-21</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
+    <image:image>
+      <image:loc>https://bennyhartnett.com/assets/og-projects.png</image:loc>
+      <image:title>Projects Portfolio - AI, IoT, Government Tech, and Nuclear</image:title>
+    </image:image>
   </url>
   <url>
-    <loc>https://bennyhartnett.com/government-contracting</loc>
-    <lastmod>2026-01-06</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.8</priority>
-  </url>
-  <url>
-    <loc>https://bennyhartnett.com/projects</loc>
-    <lastmod>2026-01-06</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.8</priority>
-  </url>
-  <url>
-    <loc>https://bennyhartnett.com/contact</loc>
-    <lastmod>2026-01-06</lastmod>
+    <loc>https://contact.bennyhartnett.com/</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://contact.bennyhartnett.com/"/>
+    <lastmod>2026-01-21</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://bennyhartnett.com/privacy</loc>
-    <lastmod>2026-01-06</lastmod>
+    <loc>https://chat.bennyhartnett.com/</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://chat.bennyhartnett.com/"/>
+    <lastmod>2026-01-21</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://privacy.bennyhartnett.com/</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://privacy.bennyhartnett.com/"/>
+    <lastmod>2026-01-21</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.3</priority>
   </url>
-  <!-- LLM-specific content files -->
+  <!-- External profile redirect subdomains -->
+  <url>
+    <loc>https://github.bennyhartnett.com/</loc>
+    <lastmod>2026-01-21</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://linkedin.bennyhartnett.com/</loc>
+    <lastmod>2026-01-21</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <!-- LLM-specific content files (served from main domain) -->
   <url>
     <loc>https://bennyhartnett.com/llms.txt</loc>
-    <lastmod>2026-01-06</lastmod>
-    <changefreq>monthly</changefreq>
+    <lastmod>2026-01-21</lastmod>
+    <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://bennyhartnett.com/llms-full.txt</loc>
-    <lastmod>2026-01-06</lastmod>
-    <changefreq>monthly</changefreq>
+    <lastmod>2026-01-21</lastmod>
+    <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <!-- Discovery files for crawlers and AI systems -->
   <url>
     <loc>https://bennyhartnett.com/humans.txt</loc>
-    <lastmod>2026-01-06</lastmod>
+    <lastmod>2026-01-21</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://bennyhartnett.com/.well-known/ai-plugin.json</loc>
-    <lastmod>2026-01-06</lastmod>
+    <lastmod>2026-01-21</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://bennyhartnett.com/.well-known/security.txt</loc>
-    <lastmod>2026-01-10</lastmod>
+    <lastmod>2026-01-21</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.5</priority>
   </url>

--- a/sw.js
+++ b/sw.js
@@ -1,6 +1,6 @@
 // Service Worker for SWU Calculator PWA
 // Version must be updated when deploying new code to bust cache
-const CACHE_VERSION = 'v45';
+const CACHE_VERSION = 'v46';
 const CACHE_NAME = `swu-calculator-${CACHE_VERSION}`;
 
 // Files to cache for offline use


### PR DESCRIPTION
- Migrate all page URLs from paths to subdomains (e.g., /nuclear -> nuclear.bennyhartnett.com)
- Add github.bennyhartnett.com and linkedin.bennyhartnett.com to sitemap
- Enhanced sitemap.xml with image sitemap extensions and hreflang tags
- Updated robots.txt with subdomain architecture documentation
- Updated llms.txt and llms-full.txt with subdomain site structure
- Added enterprise SEO: hreflang, dns-prefetch, alternate links
- Added SiteNavigationElement and enhanced WebSite JSON-LD schemas
- Updated BreadcrumbList, FAQPage, Organization schemas with subdomain URLs
- Added LLM discovery link tags (llms.txt, llms-full.txt)
- Increment CACHE_VERSION to v46