### PR TITLE
Mobile optimize the chat page

### DIFF
--- a/pages/chat.html
+++ b/pages/chat.html
@@ -527,6 +527,32 @@
     background: color-mix(in srgb, var(--wave-color, #6366f1) 50%, rgba(255, 255, 255, 0.3));
   }
 
+  /* Tablet breakpoint */
+  @media (max-width: 768px) {
+    .chat-container {
+      padding: 0.75rem;
+    }
+
+    .chat-header {
+      margin-bottom: 1rem;
+      padding-bottom: 0.75rem;
+    }
+
+    .message-content {
+      max-width: 80%;
+    }
+
+    .message-avatar {
+      width: 48px;
+      height: 48px;
+    }
+
+    .welcome-message {
+      padding: 1.5rem;
+    }
+  }
+
+  /* Mobile breakpoint */
   @media (max-width: 600px) {
     .chat-container {
       padding: 0.5rem;
@@ -534,18 +560,245 @@
       height: calc(100vh - 56px - 1rem - 28px - env(safe-area-inset-bottom, 0px));
     }
 
+    .chat-header {
+      margin-bottom: 0.75rem;
+      padding-bottom: 0.5rem;
+    }
+
     .chat-header h1 {
       font-size: 1.25rem;
     }
 
+    .chat-header p {
+      font-size: 0.8rem;
+    }
+
+    .chat-messages {
+      padding: 0.5rem 0;
+      gap: 0.75rem;
+      margin-bottom: 0.5rem;
+    }
+
+    .message {
+      gap: 0.5rem;
+    }
+
+    .message-avatar {
+      width: 40px;
+      height: 40px;
+      font-size: 0.75rem;
+    }
+
     .message-content {
       max-width: 85%;
+      padding: 0.75rem;
       font-size: 0.9rem;
+      border-radius: 14px;
+    }
+
+    .message.assistant .message-content {
+      border-radius: 14px 14px 14px 4px;
+    }
+
+    .message.user .message-content {
+      border-radius: 14px 14px 4px 14px;
+    }
+
+    /* Code block mobile optimization */
+    .message-content .code-block {
+      padding: 0.5rem 0.75rem;
+      margin: 0.375rem 0;
+      font-size: 0.8rem;
+      max-width: 100%;
+      overflow-x: auto;
+      -webkit-overflow-scrolling: touch;
+    }
+
+    .message-content .code-block code {
+      font-size: 0.8em;
+    }
+
+    .message-content code {
+      font-size: 0.8em;
+      padding: 0.1rem 0.3rem;
+    }
+
+    /* Lists mobile optimization */
+    .message-content .md-ul,
+    .message-content .md-ol {
+      padding-left: 1.25rem;
+    }
+
+    /* Input container mobile optimization */
+    .chat-input-container {
+      border-radius: 20px;
+      padding: 0.375rem;
+      gap: 0.375rem;
+    }
+
+    .chat-input {
+      font-size: 0.95rem;
+      padding: 0.625rem 0.75rem;
+      max-height: 120px;
+    }
+
+    .send-button {
+      width: 40px;
+      height: 40px;
+    }
+
+    .send-button svg {
+      width: 18px;
+      height: 18px;
+    }
+
+    /* Welcome message mobile optimization */
+    .welcome-message {
+      padding: 1rem;
+    }
+
+    .welcome-message h2 {
+      font-size: 1.1rem;
+    }
+
+    .welcome-message p {
+      font-size: 0.85rem;
+    }
+
+    .suggestion-chips {
+      gap: 0.375rem;
     }
 
     .suggestion-chip {
       font-size: 0.8rem;
       padding: 0.4rem 0.8rem;
+    }
+
+    /* Typing indicator mobile */
+    .typing-indicator .thinking-text {
+      font-size: 0.8rem;
+    }
+
+    .typing-indicator .dots span {
+      width: 6px;
+      height: 6px;
+    }
+
+    /* Link badges mobile */
+    .message-content .link-badge {
+      font-size: 0.8em;
+      padding: 0.15rem 0.5rem;
+    }
+
+    /* Headers mobile */
+    .message-content .md-h1 {
+      font-size: 1.2em;
+    }
+
+    .message-content .md-h2 {
+      font-size: 1.1em;
+    }
+
+    .message-content .md-h3 {
+      font-size: 1em;
+    }
+  }
+
+  /* Small phone breakpoint */
+  @media (max-width: 400px) {
+    .chat-container {
+      padding: 0.375rem;
+      padding-bottom: calc(0.375rem + env(safe-area-inset-bottom, 0px));
+    }
+
+    .chat-header h1 {
+      font-size: 1.1rem;
+    }
+
+    .chat-header p {
+      font-size: 0.75rem;
+    }
+
+    .message-avatar {
+      width: 36px;
+      height: 36px;
+      font-size: 0.7rem;
+    }
+
+    .message-content {
+      max-width: 88%;
+      padding: 0.625rem;
+      font-size: 0.85rem;
+    }
+
+    .chat-input {
+      font-size: 0.9rem;
+      padding: 0.5rem 0.625rem;
+    }
+
+    .send-button {
+      width: 36px;
+      height: 36px;
+    }
+
+    .send-button svg {
+      width: 16px;
+      height: 16px;
+    }
+
+    .welcome-message h2 {
+      font-size: 1rem;
+    }
+
+    .welcome-message p {
+      font-size: 0.8rem;
+    }
+
+    .suggestion-chip {
+      font-size: 0.75rem;
+      padding: 0.35rem 0.7rem;
+    }
+  }
+
+  /* Landscape mode optimization */
+  @media (max-height: 500px) and (orientation: landscape) {
+    .chat-container {
+      height: calc(100vh - 56px - 0.5rem - 28px - env(safe-area-inset-bottom, 0px));
+    }
+
+    .chat-header {
+      margin-bottom: 0.5rem;
+      padding-bottom: 0.375rem;
+    }
+
+    .chat-header h1 {
+      font-size: 1.1rem;
+    }
+
+    .chat-header p {
+      display: none;
+    }
+
+    .chat-messages {
+      padding: 0.25rem 0;
+      gap: 0.5rem;
+    }
+
+    .welcome-message {
+      padding: 0.5rem;
+    }
+
+    .welcome-message h2 {
+      font-size: 1rem;
+      margin-bottom: 0.5rem;
+    }
+
+    .welcome-message p {
+      display: none;
+    }
+
+    .chat-input {
+      max-height: 80px;
     }
   }
 </style>

--- a/sw.js
+++ b/sw.js
@@ -1,6 +1,6 @@
 // Service Worker for SWU Calculator PWA
 // Version must be updated when deploying new code to bust cache
-const CACHE_VERSION = 'v48';
+const CACHE_VERSION = 'v49';
 const CACHE_NAME = `swu-calculator-${CACHE_VERSION}`;
 
 // Files to cache for offline use


### PR DESCRIPTION
- Add tablet breakpoint (768px) with intermediate sizing
- Enhance mobile breakpoint (600px) with:
  - Reduced avatar sizes (56px -> 40px)
  - Optimized header spacing and font sizes
  - Smaller input container and send button
  - Code block horizontal scroll with touch support
  - Smaller typography and tighter spacing
- Add small phone breakpoint (400px) for extra small screens
- Add landscape mode optimization (max-height: 500px)
- Optimize welcome message, suggestion chips, and typing indicator
- Increment cache version to v49