### PR TITLE
Add autocomplete suggestions to contact message box

### DIFF
--- a/pages/contact.html
+++ b/pages/contact.html
@@ -70,6 +70,45 @@
     min-height: 75px;
     resize: vertical;
   }
+
+  /* Message Autocomplete Ghost Text Styles */
+  .message-autocomplete-wrapper {
+    position: relative;
+    width: 100%;
+  }
+  .message-autocomplete-wrapper textarea {
+    position: relative;
+    z-index: 2;
+    background: transparent;
+  }
+  .message-autocomplete-ghost {
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    z-index: 1;
+    pointer-events: none;
+    white-space: pre-wrap;
+    word-wrap: break-word;
+    overflow: hidden;
+    /* Match textarea styling exactly */
+    background: rgba(255, 255, 255, 0.08);
+    border: 1px solid transparent;
+    border-radius: 8px;
+    padding: 0.75rem;
+    font-family: 'Inter', sans-serif;
+    font-size: 1rem;
+    color: transparent;
+    line-height: normal;
+    box-sizing: border-box;
+  }
+  .message-autocomplete-ghost .typed {
+    color: transparent;
+  }
+  .message-autocomplete-ghost .suggestion {
+    color: rgba(255, 255, 255, 0.4);
+  }
   .submit-btn {
     background: var(--wave-color);
     color: white;
@@ -147,9 +186,231 @@
 
     <div class="form-group">
       <label for="message">Message</label>
-      <textarea id="message" name="message" placeholder="Your message..." required inputmode="text"></textarea>
+      <div class="message-autocomplete-wrapper">
+        <div class="message-autocomplete-ghost" aria-hidden="true"><span class="typed"></span><span class="suggestion"></span></div>
+        <textarea id="message" name="message" placeholder="Your message..." required inputmode="text" aria-autocomplete="list" aria-expanded="false"></textarea>
+      </div>
     </div>
 
     <button type="submit" class="submit-btn">Send Message</button>
   </form>
 </div>
+
+<script>
+/**
+ * Message Autocomplete Feature
+ *
+ * Shows inline ghost text suggestions based on the first letter typed (A-Z).
+ * TAB or ENTER accepts the suggestion with a typewriter animation.
+ *
+ * How to test:
+ * 1. Type "A" in the message field → ghost shows "re you available for hire?"
+ * 2. Type "Are yo" → ghost continues showing remaining characters
+ * 3. Type something that breaks prefix (e.g., "Ax") → ghost hides and stays hidden for "A"
+ * 4. Press TAB or ENTER when ghost visible → typewriter fills the full sentence
+ * 5. Press ESC → hides ghost without lockout
+ * 6. Clear field or change first letter → resets lockout
+ */
+(function() {
+  const SUGGESTIONS = {
+    "A": "Are you available for hire?",
+    "B": "Big fan of your work—open to an interview?",
+    "C": "Can we set up a quick interview?",
+    "D": "Do you have time for a hiring call?",
+    "E": "Excited to chat—available this week?",
+    "F": "Full-time role—interested in talking?",
+    "G": "Great fit for our team—can we interview you?",
+    "H": "Hiring now—are you open to a full-time role?",
+    "I": "Interested in a full-time engineering position?",
+    "J": "Join our team as a full-time developer?",
+    "K": "Keen to meet—when can you interview?",
+    "L": "Let's schedule an interview.",
+    "M": "Meet with our hiring team?",
+    "N": "Next step: can you interview this week?",
+    "O": "Open to a full-time opportunity?",
+    "P": "Please send availability for an interview.",
+    "Q": "Quick call to discuss the role?",
+    "R": "Ready for a technical interview?",
+    "S": "Schedule a video interview this week?",
+    "T": "Talk with our team about a full-time role?",
+    "U": "Up for a job?",
+    "V": "Video call sometime this week?",
+    "W": "We'd like to interview you—available?",
+    "X": "Xcode job interview—are you interested?",
+    "Y": "You look like the perfect candidate—are you available for an interview?",
+    "Z": "Zoom interview this week?"
+  };
+
+  const textarea = document.getElementById('message');
+  const ghost = document.querySelector('.message-autocomplete-ghost');
+  const typedSpan = ghost.querySelector('.typed');
+  const suggestionSpan = ghost.querySelector('.suggestion');
+
+  let lockedOutLetters = new Set();
+  let animationFrameId = null;
+  let isAnimating = false;
+  let currentSuggestion = '';
+  let suggestionVisible = false;
+
+  function getFirstLetter(value) {
+    const trimmed = value.trimStart();
+    if (!trimmed) return null;
+    const firstChar = trimmed.charAt(0).toUpperCase();
+    return /[A-Z]/.test(firstChar) ? firstChar : null;
+  }
+
+  function updateGhost(typed, remaining) {
+    typedSpan.textContent = typed;
+    suggestionSpan.textContent = remaining;
+    suggestionVisible = remaining.length > 0;
+    textarea.setAttribute('aria-expanded', suggestionVisible ? 'true' : 'false');
+  }
+
+  function hideGhost() {
+    updateGhost('', '');
+    currentSuggestion = '';
+  }
+
+  function handleInput() {
+    if (isAnimating) {
+      cancelAnimation();
+    }
+
+    const value = textarea.value;
+    const letter = getFirstLetter(value);
+
+    // No letter typed yet
+    if (!letter) {
+      hideGhost();
+      lockedOutLetters.clear();
+      return;
+    }
+
+    // Get suggestion for this letter
+    const suggestion = SUGGESTIONS[letter];
+    if (!suggestion) {
+      hideGhost();
+      return;
+    }
+
+    // Check if this letter is locked out
+    if (lockedOutLetters.has(letter)) {
+      hideGhost();
+      return;
+    }
+
+    // Get value with leading spaces removed for prefix matching
+    const trimmedValue = value.trimStart();
+
+    // Check if typed text is a case-insensitive prefix of the suggestion
+    if (suggestion.toLowerCase().startsWith(trimmedValue.toLowerCase())) {
+      currentSuggestion = suggestion;
+      const remaining = suggestion.slice(trimmedValue.length);
+      updateGhost(value, remaining);
+    } else {
+      // Prefix doesn't match - lockout this letter
+      lockedOutLetters.add(letter);
+      hideGhost();
+    }
+  }
+
+  function cancelAnimation() {
+    if (animationFrameId) {
+      cancelAnimationFrame(animationFrameId);
+      animationFrameId = null;
+    }
+    isAnimating = false;
+  }
+
+  function acceptSuggestion() {
+    if (!suggestionVisible || !currentSuggestion) return false;
+
+    const targetText = currentSuggestion;
+    const startText = textarea.value.trimStart();
+    const startIndex = startText.length;
+
+    // If already complete, nothing to animate
+    if (startIndex >= targetText.length) {
+      hideGhost();
+      return true;
+    }
+
+    isAnimating = true;
+    let currentIndex = startIndex;
+
+    function typeNextChar() {
+      if (!isAnimating || currentIndex >= targetText.length) {
+        isAnimating = false;
+        hideGhost();
+        return;
+      }
+
+      currentIndex++;
+      textarea.value = targetText.slice(0, currentIndex);
+      textarea.setSelectionRange(currentIndex, currentIndex);
+
+      // Update ghost to show remaining
+      const remaining = targetText.slice(currentIndex);
+      updateGhost(textarea.value, remaining);
+
+      if (currentIndex < targetText.length) {
+        animationFrameId = requestAnimationFrame(() => {
+          setTimeout(typeNextChar, 15); // ~15ms per character
+        });
+      } else {
+        isAnimating = false;
+        hideGhost();
+      }
+    }
+
+    typeNextChar();
+    return true;
+  }
+
+  function handleKeyDown(e) {
+    // TAB: accept suggestion (not Shift+Tab)
+    if (e.key === 'Tab' && !e.shiftKey && suggestionVisible) {
+      e.preventDefault();
+      acceptSuggestion();
+      return;
+    }
+
+    // ENTER: accept suggestion only if visible
+    if (e.key === 'Enter' && suggestionVisible) {
+      e.preventDefault();
+      acceptSuggestion();
+      return;
+    }
+
+    // ESC: hide ghost without lockout
+    if (e.key === 'Escape' && suggestionVisible) {
+      e.preventDefault();
+      hideGhost();
+      return;
+    }
+  }
+
+  // Cancel animation on user interaction during animation
+  function handleInteraction() {
+    if (isAnimating) {
+      cancelAnimation();
+      // Re-evaluate the current state
+      handleInput();
+    }
+  }
+
+  textarea.addEventListener('input', handleInput);
+  textarea.addEventListener('keydown', handleKeyDown);
+  textarea.addEventListener('click', handleInteraction);
+  textarea.addEventListener('mousedown', handleInteraction);
+
+  // Also handle focus to reset when field is focused fresh
+  textarea.addEventListener('focus', () => {
+    // Just re-evaluate on focus
+    handleInput();
+  });
+
+  // Initialize
+  handleInput();
+})();
+</script>

--- a/sw.js
+++ b/sw.js
@@ -1,6 +1,6 @@
 // Service Worker for SWU Calculator PWA
 // Version must be updated when deploying new code to bust cache
-const CACHE_VERSION = 'v51';
+const CACHE_VERSION = 'v52';
 const CACHE_NAME = `swu-calculator-${CACHE_VERSION}`;
 
 // Files to cache for offline use


### PR DESCRIPTION
Implements inline ghost text suggestions that appear when users type in the message field. The suggestions are based on the first letter typed (A-Z) and show hiring-related messages.

Features:
- Ghost text overlay showing remaining suggestion characters
- TAB or ENTER accepts suggestion with typewriter animation (~15ms/char)
- ESC hides suggestion without lockout
- Strict prefix matching with lockout when user diverges from suggestion
- Lockout resets when field is cleared or first letter changes
- Accessibility: aria-autocomplete and aria-expanded attributes
- No external dependencies

Bump sw.js cache to v52.