### PR TITLE
Add LinkedIn and Contact buttons to resume page

### DIFF
--- a/pages/resume.html
+++ b/pages/resume.html
@@ -46,6 +46,23 @@
     width: 18px;
     height: 18px;
   }
+  .button-row {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    justify-content: center;
+    align-items: center;
+    margin-bottom: 1rem;
+  }
+  .button-row .download-btn {
+    margin-bottom: 0;
+  }
+  @media (max-width: 480px) {
+    .button-row {
+      flex-direction: column;
+      gap: 0.5rem;
+    }
+  }
   .pdf-pages {
     box-shadow: 0 2px 10px rgba(0,0,0,0.3);
     background: white;
@@ -192,14 +209,29 @@
   }
 </style>
 <div class="pdf-container">
-  <a data-href="https://download.bennyhartnett.com" data-external="true" class="download-btn">
-    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-      <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path>
-      <polyline points="7 10 12 15 17 10"></polyline>
-      <line x1="12" y1="15" x2="12" y2="3"></line>
-    </svg>
-    Download My Resume
-  </a>
+  <div class="button-row">
+    <a data-href="https://www.linkedin.com/in/bennyhartnett" data-external="true" class="download-btn">
+      <svg viewBox="0 0 24 24" fill="currentColor">
+        <path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433c-1.144 0-2.063-.926-2.063-2.065 0-1.138.92-2.063 2.063-2.063 1.14 0 2.064.925 2.064 2.063 0 1.139-.925 2.065-2.064 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z"/>
+      </svg>
+      LinkedIn
+    </a>
+    <a data-href="https://download.bennyhartnett.com" data-external="true" class="download-btn">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+        <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path>
+        <polyline points="7 10 12 15 17 10"></polyline>
+        <line x1="12" y1="15" x2="12" y2="3"></line>
+      </svg>
+      Download My Resume
+    </a>
+    <a href="/contact" class="download-btn">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+        <path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z"></path>
+        <polyline points="22,6 12,13 2,6"></polyline>
+      </svg>
+      Contact Me
+    </a>
+  </div>
   <div class="pdf-loading" id="pdf-loading">Loading resume...</div>
   <div class="pdf-pages" id="pdf-pages"></div>
 </div>

--- a/sw.js
+++ b/sw.js
@@ -1,6 +1,6 @@
 // Service Worker for SWU Calculator PWA
 // Version must be updated when deploying new code to bust cache
-const CACHE_VERSION = 'v53';
+const CACHE_VERSION = 'v54';
 const CACHE_NAME = `swu-calculator-${CACHE_VERSION}`;
 
 // Files to cache for offline use


### PR DESCRIPTION
## Summary
Enhanced the resume page with a new button row layout containing LinkedIn profile link and Contact page link alongside the existing Download Resume button. Updated service worker cache version to invalidate old cached assets.

## Changes
- **Added button row layout** with flexbox styling for responsive button grouping
  - Horizontal layout on desktop with centered alignment and 0.75rem gap
  - Vertical stacked layout on mobile (≤480px) with reduced 0.5rem gap
  - Removed individual button margins in favor of row-level gap management

- **Added two new action buttons**:
  - LinkedIn button linking to professional profile with LinkedIn SVG icon
  - Contact button linking to `/contact` page with envelope SVG icon

- **Updated service worker cache version** from v53 to v54 to ensure users receive the latest resume page markup

## Implementation Details
- Reused existing `.download-btn` class styling for consistency across all three buttons
- LinkedIn button uses `data-external="true"` attribute for external link handling
- Contact button uses standard internal link without external attributes
- SVG icons match the existing design language (LinkedIn uses filled icon, others use stroke style)
- Responsive design ensures proper spacing and layout on all screen sizes