### PR TITLE
Fix zoom scaling for contact, chat, and meet pages

### DIFF
--- a/pages/chat.html
+++ b/pages/chat.html
@@ -8,8 +8,8 @@
   }
 
   .chat-container {
-    height: calc(100vh - 56px - 2rem - 28px - env(safe-area-inset-bottom, 0px));
-    height: calc(100svh - 56px - 2rem - 28px - env(safe-area-inset-bottom, 0px)); /* Mobile-friendly viewport height */
+    height: calc((100vh - 56px - 2rem - 28px - env(safe-area-inset-bottom, 0px)) / 0.75);
+    height: calc((100svh - 56px - 2rem - 28px - env(safe-area-inset-bottom, 0px)) / 0.75); /* Mobile-friendly viewport height */
     display: flex;
     flex-direction: column;
     padding: 1rem;
@@ -17,6 +17,8 @@
     max-width: 800px;
     margin: 0 auto;
     overflow: hidden;
+    transform: scale(0.75);
+    transform-origin: top center;
   }
 
   .chat-header {

--- a/pages/contact.html
+++ b/pages/contact.html
@@ -6,13 +6,15 @@
     margin: 0;
   }
   .contact-container {
-    min-height: calc(100vh - 56px - 2rem);
-    min-height: calc(100svh - 56px - 2rem); /* Mobile-friendly viewport height */
+    min-height: calc((100vh - 56px - 2rem) / 0.9);
+    min-height: calc((100svh - 56px - 2rem) / 0.9); /* Mobile-friendly viewport height */
     display: flex;
     flex-direction: column;
     justify-content: center;
     align-items: center;
     padding: 1rem;
+    transform: scale(0.9);
+    transform-origin: top center;
   }
   .contact-form {
     width: 100%;

--- a/pages/meet.html
+++ b/pages/meet.html
@@ -9,14 +9,16 @@
 
   /* Pre-join Screen */
   .prejoin-container {
-    min-height: calc(100vh - 56px);
-    min-height: calc(100svh - 56px);
+    min-height: calc((100vh - 56px) / 0.75);
+    min-height: calc((100svh - 56px) / 0.75);
     display: flex;
     flex-direction: column;
     align-items: center;
     justify-content: center;
     padding: 2rem;
     gap: 2rem;
+    transform: scale(0.75);
+    transform-origin: top center;
   }
 
   .prejoin-card {
@@ -215,12 +217,14 @@
 
   /* Meeting Room */
   .meet-container {
-    min-height: calc(100vh - 56px - 2rem);
-    min-height: calc(100svh - 56px - 2rem);
+    min-height: calc((100vh - 56px - 2rem) / 0.75);
+    min-height: calc((100svh - 56px - 2rem) / 0.75);
     display: none;
     flex-direction: column;
     padding: 1rem;
     gap: 1rem;
+    transform: scale(0.75);
+    transform-origin: top center;
   }
 
   .meet-container.active {

--- a/sw.js
+++ b/sw.js
@@ -1,6 +1,6 @@
 // Service Worker for SWU Calculator PWA
 // Version must be updated when deploying new code to bust cache
-const CACHE_VERSION = 'v56';
+const CACHE_VERSION = 'v57';
 const CACHE_NAME = `swu-calculator-${CACHE_VERSION}`;
 
 // Files to cache for offline use


### PR DESCRIPTION
- Contact page: scale(0.9) - 100% view looks like 90% zoom
- Chat page: scale(0.75) - 100% view looks like 75% zoom
- Meet page: scale(0.75) - 100% view looks like 75% zoom

Adjusted height calculations to account for scaling factor and bumped CACHE_VERSION to v57 for PWA cache bust.