### PR TITLE
Fix WebSocket connection failures for relay

### DIFF
--- a/pages/meet.html
+++ b/pages/meet.html
@@ -2060,7 +2060,7 @@
 
 <script type="module">
   // Import Trystero for serverless WebRTC
-  import { joinRoom } from 'https://esm.sh/trystero@0.20.0';
+  import { joinRoom } from 'https://esm.sh/trystero@0.20.0/torrent';
 
   // App state
   const state = {

--- a/sw.js
+++ b/sw.js
@@ -1,6 +1,6 @@
 // Service Worker for SWU Calculator PWA
 // Version must be updated when deploying new code to bust cache
-const CACHE_VERSION = 'v60';
+const CACHE_VERSION = 'v61';
 const CACHE_NAME = `swu-calculator-${CACHE_VERSION}`;
 
 // Files to cache for offline use


### PR DESCRIPTION
Changed Trystero import from base package to torrent strategy module. The default Nostr relays (nostr.lu.ke, relay.piazza.today, relay.exit.pub) were failing. Using WebTorrent trackers for signaling is more reliable.