### PR TITLE
Fix mobile web app meta tags and join error

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,7 +37,7 @@
   <link rel="shortcut icon" href="/favicon.svg" />
   <meta name="robots" content="index,follow" />
   <meta name="theme-color" content="#0D6EFD" />
-  <meta name="apple-mobile-web-app-capable" content="yes" />
+  <meta name="mobile-web-app-capable" content="yes" />
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
   <link rel="apple-touch-icon" href="/favicon.svg" />
   <link rel="mask-icon" href="/favicon.svg" color="#0D6EFD" />

--- a/nuclear.html
+++ b/nuclear.html
@@ -11,7 +11,7 @@
   <link rel="canonical" href="https://bennyhartnett.com/nuclear" />
 
   <!-- iOS PWA meta tags to hide Safari UI in standalone mode -->
-  <meta name="apple-mobile-web-app-capable" content="yes" />
+  <meta name="mobile-web-app-capable" content="yes" />
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
   <meta name="apple-mobile-web-app-title" content="SWU Calc" />
   <meta name="theme-color" content="#0ea5e9" />
@@ -665,7 +665,7 @@
   <link rel="apple-touch-icon" href="/centrus_icon.png" />
   <link rel="apple-touch-startup-image" href="/centrus_icon.png" />
   <meta name="apple-mobile-web-app-title" content="SWU Calculator" />
-  <meta name="apple-mobile-web-app-capable" content="yes" />
+  <meta name="mobile-web-app-capable" content="yes" />
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
   <link rel="manifest" href="/config/manifest.webmanifest" />
 </head>

--- a/pages/meet.html
+++ b/pages/meet.html
@@ -1782,6 +1782,19 @@
       </svg>
       Spotlight
     </button>
+    <div class="meeting-info">
+      <div class="participant-count" id="participant-count">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2"/>
+          <circle cx="9" cy="7" r="4"/>
+        </svg>
+        <span id="count-text">1 participant</span>
+      </div>
+      <div class="connection-status connecting" id="connection-status">
+        <span class="dot"></span>
+        <span id="connection-text">Connecting</span>
+      </div>
+    </div>
   </div>
 
   <div class="video-grid single" id="video-grid">

--- a/sw.js
+++ b/sw.js
@@ -1,6 +1,6 @@
 // Service Worker for SWU Calculator PWA
 // Version must be updated when deploying new code to bust cache
-const CACHE_VERSION = 'v61';
+const CACHE_VERSION = 'v62';
 const CACHE_NAME = `swu-calculator-${CACHE_VERSION}`;
 
 // Files to cache for offline use


### PR DESCRIPTION
- Replace deprecated apple-mobile-web-app-capable with mobile-web-app-capable
- Add missing connection-status, connection-text, participant-count, and count-text HTML elements that caused classList null error when joining
- Increment cache version to v62