### PR TITLE
Fix stream propagation for late joiners and media state changes

### DIFF
--- a/pages/meet.html
+++ b/pages/meet.html
@@ -2435,6 +2435,14 @@
       sendName(state.userName, peerId);
       sendMediaState({ mic: state.micEnabled, camera: state.cameraEnabled }, peerId);
 
+      // Send our current stream to the new peer
+      // This ensures late joiners receive video/screen share
+      if (state.screenSharing && state.screenStream) {
+        state.room.addStream(state.screenStream, peerId);
+      } else if (state.localStream) {
+        state.room.addStream(state.localStream, peerId);
+      }
+
       // Send hand raise state if raised
       if (state.handRaised) {
         sendHandRaise({ raised: true, peerId: state.peerId, name: state.userName, time: Date.now() }, peerId);
@@ -2802,6 +2810,10 @@
       const audioTracks = state.localStream?.getAudioTracks();
       if (audioTracks && audioTracks.length > 0) {
         audioTracks.forEach(t => t.enabled = true);
+        // Re-add stream to ensure track state is propagated to peers
+        if (state.localStream) {
+          state.room?.addStream(state.localStream);
+        }
       } else {
         // Need to get new audio stream
         const newStream = await requestMedia(true, state.cameraEnabled);
@@ -2838,6 +2850,10 @@
       const videoTracks = state.localStream?.getVideoTracks();
       if (videoTracks && videoTracks.length > 0) {
         videoTracks.forEach(t => t.enabled = true);
+        // Re-add stream to ensure track state is propagated to peers
+        if (state.localStream) {
+          state.room?.addStream(state.localStream);
+        }
       } else {
         // Need to get new video stream
         const newStream = await requestMedia(state.micEnabled, true);

--- a/sw.js
+++ b/sw.js
@@ -1,6 +1,6 @@
 // Service Worker for SWU Calculator PWA
 // Version must be updated when deploying new code to bust cache
-const CACHE_VERSION = 'v62';
+const CACHE_VERSION = 'v63';
 const CACHE_NAME = `swu-calculator-${CACHE_VERSION}`;
 
 // Files to cache for offline use


### PR DESCRIPTION
## Summary
This PR fixes stream handling in the video conferencing feature to ensure that late-joining participants receive the correct media streams (video or screen share) and that media state changes (mic/camera toggling) are properly propagated to all peers.

## Key Changes
- **Late joiner stream handling**: When a new peer joins, the application now explicitly sends the current local stream or screen share stream to them, ensuring they receive video/screen share immediately rather than waiting for renegotiation
- **Media state propagation**: When re-enabling audio or video tracks, the stream is now re-added to the room to ensure the track state changes are propagated to all connected peers
- **Service worker cache**: Updated cache version from v62 to v63 to invalidate old cached assets

## Implementation Details
- Added stream transmission logic in the peer connection handler that checks if screen sharing is active before sending the appropriate stream
- Implemented stream re-addition after enabling audio/video tracks to trigger peer notifications of track state changes
- The fix handles both scenarios: when tracks already exist (just need to be re-enabled) and when new streams need to be requested