### PR TITLE
Add audio track validation to speaking detection setup

### DIFF
--- a/pages/meet.html
+++ b/pages/meet.html
@@ -2636,6 +2636,11 @@
   // Set up speaking detection
   function setupSpeakingDetection(peerId, stream) {
     try {
+      // Check if stream has audio tracks before setting up detection
+      if (!stream || !stream.getAudioTracks().length) {
+        return; // No audio track, skip speaking detection
+      }
+
       const audioContext = new AudioContext();
       const analyser = audioContext.createAnalyser();
       const source = audioContext.createMediaStreamSource(stream);

--- a/sw.js
+++ b/sw.js
@@ -1,6 +1,6 @@
 // Service Worker for SWU Calculator PWA
 // Version must be updated when deploying new code to bust cache
-const CACHE_VERSION = 'v63';
+const CACHE_VERSION = 'v64';
 const CACHE_NAME = `swu-calculator-${CACHE_VERSION}`;
 
 // Files to cache for offline use


### PR DESCRIPTION
## Summary
This PR adds a safety check to the speaking detection initialization to prevent errors when processing streams without audio tracks, and bumps the service worker cache version.

## Key Changes
- **Speaking Detection Robustness**: Added validation in `setupSpeakingDetection()` to check if the stream has audio tracks before attempting to set up audio analysis. If no audio tracks are present, the function now returns early instead of attempting to create an AudioContext and analyser.
- **Cache Invalidation**: Updated service worker cache version from `v63` to `v64` to ensure clients receive the latest code.

## Implementation Details
The audio track validation uses `stream.getAudioTracks().length` to safely determine if audio is available before proceeding with AudioContext initialization. This prevents potential runtime errors that could occur when the function is called with streams that only contain video tracks or are otherwise audio-less.