### PR TITLE
Add tools showcase page with grid layout

### DIFF
--- a/pages/tools.html
+++ b/pages/tools.html
@@ -1,0 +1,167 @@
+<style>
+  @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap');
+  body {
+    font-family: 'Inter', sans-serif;
+    color: white;
+    margin: 0;
+  }
+  .tools-container {
+    min-height: calc(100vh - 56px - 2rem);
+    min-height: calc(100svh - 56px - 2rem);
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    padding: 2rem 1rem;
+  }
+  .tools-header {
+    text-align: center;
+    margin-bottom: 2rem;
+  }
+  .tools-header h1 {
+    font-size: 2rem;
+    margin: 0 0 0.5rem 0;
+  }
+  .tools-header p {
+    color: rgba(255, 255, 255, 0.7);
+    margin: 0;
+  }
+  .tools-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: 1.5rem;
+    width: 100%;
+    max-width: 900px;
+  }
+  .tool-card {
+    display: flex;
+    flex-direction: column;
+    padding: 1.5rem;
+    border-radius: 12px;
+    background: rgba(255, 255, 255, 0.05);
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    text-decoration: none;
+    color: white;
+    transition: all 0.3s ease;
+  }
+  .tool-card:hover {
+    background: rgba(255, 255, 255, 0.1);
+    border-color: var(--wave-color, rgba(255, 255, 255, 0.3));
+    transform: translateY(-2px);
+  }
+  .tool-card:focus-visible {
+    outline: 2px solid var(--wave-color);
+    outline-offset: 4px;
+  }
+  .tool-icon {
+    font-size: 2rem;
+    margin-bottom: 0.75rem;
+  }
+  .tool-card h2 {
+    font-size: 1.25rem;
+    margin: 0 0 0.5rem 0;
+  }
+  .tool-card p {
+    font-size: 0.9rem;
+    color: rgba(255, 255, 255, 0.7);
+    margin: 0;
+    flex-grow: 1;
+  }
+  .tool-card .tool-tag {
+    display: inline-block;
+    font-size: 0.75rem;
+    padding: 0.25rem 0.5rem;
+    border-radius: 4px;
+    background: rgba(255, 255, 255, 0.1);
+    margin-top: 1rem;
+    align-self: flex-start;
+  }
+  .tool-card.coming-soon {
+    opacity: 0.5;
+    pointer-events: none;
+  }
+  .tool-card.coming-soon .tool-tag {
+    background: rgba(255, 255, 255, 0.05);
+  }
+
+  /* Dark mode scrollbar */
+  ::-webkit-scrollbar {
+    width: 12px;
+  }
+  ::-webkit-scrollbar-track {
+    background: #111;
+  }
+  ::-webkit-scrollbar-thumb {
+    background: #444;
+    border-radius: 6px;
+  }
+  ::-webkit-scrollbar-thumb:hover {
+    background: #555;
+  }
+  * {
+    scrollbar-width: thin;
+    scrollbar-color: #444 #111;
+  }
+
+  @media (max-width: 600px) {
+    .tools-container {
+      padding: 1.5rem 1rem;
+    }
+    .tools-header h1 {
+      font-size: 1.5rem;
+    }
+    .tools-grid {
+      grid-template-columns: 1fr;
+    }
+  }
+</style>
+
+<div class="tools-container">
+  <div class="tools-header">
+    <h1>Tools</h1>
+    <p>Apps and utilities I've built</p>
+  </div>
+
+  <div class="tools-grid">
+    <a href="/meet" class="tool-card">
+      <span class="tool-icon">📹</span>
+      <h2>Meet</h2>
+      <p>Video conferencing with screen sharing, real-time collaboration, and no sign-up required.</p>
+      <span class="tool-tag">Video</span>
+    </a>
+
+    <a href="/nuclear" class="tool-card">
+      <span class="tool-icon">⚛️</span>
+      <h2>Nuclear Calculator</h2>
+      <p>SWU calculator for uranium enrichment economics. Compute separative work units and costs.</p>
+      <span class="tool-tag">Calculator</span>
+    </a>
+
+    <a href="/chat" class="tool-card">
+      <span class="tool-icon">💬</span>
+      <h2>AI Chat</h2>
+      <p>Chat with an AI assistant trained on my background, projects, and experience.</p>
+      <span class="tool-tag">AI</span>
+    </a>
+
+    <div class="tool-card coming-soon">
+      <span class="tool-icon">🔧</span>
+      <h2>Coming Soon</h2>
+      <p>More tools are on the way. Check back for updates.</p>
+      <span class="tool-tag">Coming Soon</span>
+    </div>
+
+    <div class="tool-card coming-soon">
+      <span class="tool-icon">🔧</span>
+      <h2>Coming Soon</h2>
+      <p>More tools are on the way. Check back for updates.</p>
+      <span class="tool-tag">Coming Soon</span>
+    </div>
+
+    <div class="tool-card coming-soon">
+      <span class="tool-icon">🔧</span>
+      <h2>Coming Soon</h2>
+      <p>More tools are on the way. Check back for updates.</p>
+      <span class="tool-tag">Coming Soon</span>
+    </div>
+  </div>
+</div>

--- a/sw.js
+++ b/sw.js
@@ -1,6 +1,6 @@
 // Service Worker for SWU Calculator PWA
 // Version must be updated when deploying new code to bust cache
-const CACHE_VERSION = 'v64';
+const CACHE_VERSION = 'v65';
 const CACHE_NAME = `swu-calculator-${CACHE_VERSION}`;
 
 // Files to cache for offline use
@@ -18,6 +18,7 @@ const STATIC_ASSETS = [
   '/config/manifest.webmanifest',
   '/pages/chat.html',
   '/pages/meet.html',
+  '/pages/tools.html',
   '/assets/benny%20clear.png',
   // CSS files
   '/css/main.css',


### PR DESCRIPTION
## Summary
This PR adds a new tools showcase page that displays all available applications and utilities in a responsive grid layout. The page serves as a central hub for discovering the Meet video conferencing tool, Nuclear Calculator, AI Chat, and upcoming features.

## Changes
- **New page**: Added `/pages/tools.html` with a complete tools showcase featuring:
  - Responsive grid layout (auto-fit columns, mobile-optimized)
  - Three active tool cards (Meet, Nuclear Calculator, AI Chat) with descriptions and category tags
  - Three placeholder "Coming Soon" cards for future tools
  - Hover effects and focus states for accessibility
  - Dark mode styling with custom scrollbar
  - Inter font family for consistent typography

- **Service Worker**: Updated cache version from v64 to v65 and added `/pages/tools.html` to the static assets list for offline support

## Implementation Details
- Grid uses `repeat(auto-fit, minmax(280px, 1fr))` for responsive behavior across all screen sizes
- Tool cards are interactive links with smooth transitions and visual feedback on hover
- "Coming Soon" cards are disabled with reduced opacity and pointer-events: none
- Mobile breakpoint at 600px reduces header size and switches grid to single column
- Includes dark mode scrollbar styling for webkit and Firefox browsers
- Maintains consistent spacing and uses CSS custom properties for theming (--wave-color)