### PR TITLE
Update resume link to external URL and bump cache version

### DIFF
--- a/js/spa-router.js
+++ b/js/spa-router.js
@@ -127,7 +127,7 @@ function renderFallbackContent(url) {
       <ul class="link-list">\
         <li><a data-href="https://www.linkedin.com/in/dev-dc" data-external="true">LinkedIn</a></li>\
         <li><a data-href="https://github.com/bennyhartnett" data-external="true">GitHub</a></li>\
-        <li><a data-action="download-resume">Resume</a></li>\
+        <li><a href="https://resume.bennyhartnett.com">Resume</a></li>\
         <li><a data-href="/nuclear">Nuclear</a></li>\
         <li><a data-href="/contact">Contact</a></li>\
       </ul>\

--- a/pages/home.html
+++ b/pages/home.html
@@ -173,7 +173,7 @@
 <ul class="link-list">
       <li><a data-href="https://github.com/bennyhartnett" data-external="true">GitHub</a></li>
   <li><a data-href="https://www.linkedin.com/in/dev-dc" data-external="true">LinkedIn</a></li>
-  <li><a data-href="/resume">Resume</a></li>
+  <li><a href="https://resume.bennyhartnett.com">Resume</a></li>
   <li><a data-href="/nuclear">Nuclear</a></li>
   <li><a data-href="/contact">Contact</a></li>
 </ul>

--- a/sw.js
+++ b/sw.js
@@ -1,6 +1,6 @@
 // Service Worker for SWU Calculator PWA
 // Version must be updated when deploying new code to bust cache
-const CACHE_VERSION = 'v64';
+const CACHE_VERSION = 'v65';
 const CACHE_NAME = `swu-calculator-${CACHE_VERSION}`;
 
 // Files to cache for offline use


### PR DESCRIPTION
## Summary
Updated the resume link across the application to point to an external URL instead of using internal routing, and incremented the service worker cache version to ensure users receive the latest assets.

## Changes
- **Resume link updates**: Changed resume links from internal routes (`data-href="/resume"` and `data-action="download-resume"`) to direct external URL (`https://resume.bennyhartnett.com`) in both the SPA router fallback content and home page
- **Cache version bump**: Incremented service worker cache version from `v64` to `v65` to invalidate cached assets and force clients to fetch the latest version

## Implementation Details
- The resume link now uses a standard `href` attribute pointing to an external domain, removing the dependency on internal routing or custom download actions
- This change applies consistently across both the fallback content renderer and the home page template
- Service worker cache version update ensures all users will receive the updated links on their next visit