### PR TITLE
Rename navigation link from Nuclear to Tools

### DIFF
--- a/pages/home.html
+++ b/pages/home.html
@@ -174,7 +174,7 @@
       <li><a data-href="https://github.com/bennyhartnett" data-external="true">GitHub</a></li>
   <li><a data-href="https://www.linkedin.com/in/dev-dc" data-external="true">LinkedIn</a></li>
   <li><a href="https://resume.bennyhartnett.com">Resume</a></li>
-  <li><a data-href="/nuclear">Nuclear</a></li>
+  <li><a data-href="/tools">Tools</a></li>
   <li><a data-href="/contact">Contact</a></li>
 </ul>
   </div>

--- a/sw.js
+++ b/sw.js
@@ -1,6 +1,6 @@
 // Service Worker for SWU Calculator PWA
 // Version must be updated when deploying new code to bust cache
-const CACHE_VERSION = 'v65';
+const CACHE_VERSION = 'v66';
 const CACHE_NAME = `swu-calculator-${CACHE_VERSION}`;
 
 // Files to cache for offline use


### PR DESCRIPTION
## Summary
Updated the navigation menu to rename the "Nuclear" link to "Tools" and bumped the service worker cache version to ensure the changes are deployed to all users.

## Changes
- Changed navigation link label from `/nuclear` to `/tools` in the main navigation menu
- Incremented service worker cache version from `v65` to `v66` to bust the cache and force clients to fetch the latest assets

## Details
This change updates the primary navigation to reflect a more general "Tools" section instead of the previous "Nuclear" designation. The service worker cache version bump ensures that all users will receive the updated navigation on their next visit, preventing any stale cached versions from being served.