### PR TITLE
Update LinkedIn profile URL and cache version

### DIFF
--- a/pages/resume.html
+++ b/pages/resume.html
@@ -210,7 +210,7 @@
 </style>
 <div class="pdf-container">
   <div class="button-row">
-    <a data-href="https://www.linkedin.com/in/bennyhartnett" data-external="true" class="download-btn">
+    <a data-href="https://www.linkedin.com/in/dev-dc" data-external="true" class="download-btn">
       <svg viewBox="0 0 24 24" fill="currentColor">
         <path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433c-1.144 0-2.063-.926-2.063-2.065 0-1.138.92-2.063 2.063-2.063 1.14 0 2.064.925 2.064 2.063 0 1.139-.925 2.065-2.064 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z"/>
       </svg>

--- a/sw.js
+++ b/sw.js
@@ -1,6 +1,6 @@
 // Service Worker for SWU Calculator PWA
 // Version must be updated when deploying new code to bust cache
-const CACHE_VERSION = 'v67';
+const CACHE_VERSION = 'v68';
 const CACHE_NAME = `swu-calculator-${CACHE_VERSION}`;
 
 // Files to cache for offline use


### PR DESCRIPTION
## Summary
Updated the LinkedIn profile URL in the resume page and bumped the service worker cache version to ensure the changes are reflected for all users.

## Changes
- **pages/resume.html**: Updated LinkedIn profile URL from `bennyhartnett` to `dev-dc`
- **sw.js**: Incremented cache version from `v67` to `v68` to invalidate cached assets and force browsers to fetch the latest version

## Details
The cache version increment ensures that users will receive the updated resume page with the new LinkedIn profile link, rather than serving the outdated cached version.

https://claude.ai/code/session_018MiGcA5EL6GuJMh9P15viT