### PR TITLE
Add dark mode toggle to resume PDF viewer

### DIFF
--- a/pages/resume.html
+++ b/pages/resume.html
@@ -57,10 +57,74 @@
   .button-row .download-btn {
     margin-bottom: 0;
   }
+  /* Dark mode toggle button - icon only */
+  .dark-mode-toggle {
+    width: 44px;
+    height: 44px;
+    padding: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 50%;
+    background: rgba(255, 255, 255, 0.1);
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
+    border: 1px solid rgba(255, 255, 255, 0.2);
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.2);
+    cursor: pointer;
+    transition: transform 0.2s ease, background 0.2s ease, box-shadow 0.2s ease;
+    color: white;
+  }
+  .dark-mode-toggle:hover {
+    transform: scale(1.1);
+    background: rgba(255, 255, 255, 0.15);
+    box-shadow: 0 6px 24px rgba(0, 0, 0, 0.3);
+  }
+  .dark-mode-toggle:active {
+    transform: scale(0.95);
+  }
+  .dark-mode-toggle svg {
+    width: 22px;
+    height: 22px;
+  }
+  .dark-mode-toggle .icon-sun {
+    display: none;
+  }
+  .dark-mode-toggle .icon-moon {
+    display: block;
+  }
+  .dark-mode-toggle.active .icon-sun {
+    display: block;
+  }
+  .dark-mode-toggle.active .icon-moon {
+    display: none;
+  }
+  /* Dark mode styles for PDF */
+  .pdf-pages.dark-mode {
+    background: #1a1a1a;
+    box-shadow: 0 2px 10px rgba(0,0,0,0.5);
+  }
+  .pdf-pages.dark-mode .pdf-page canvas {
+    filter: invert(1) hue-rotate(180deg);
+  }
+  .pdf-pages.dark-mode .pdf-page .textLayer ::selection {
+    background: rgba(100, 150, 255, 0.5);
+  }
+  .pdf-pages.dark-mode .pdf-page .textLayer ::-moz-selection {
+    background: rgba(100, 150, 255, 0.5);
+  }
   @media (max-width: 480px) {
     .button-row {
       flex-direction: column;
       gap: 0.5rem;
+    }
+    .dark-mode-toggle {
+      width: 40px;
+      height: 40px;
+    }
+    .dark-mode-toggle svg {
+      width: 20px;
+      height: 20px;
     }
   }
   .pdf-pages {
@@ -210,6 +274,22 @@
 </style>
 <div class="pdf-container">
   <div class="button-row">
+    <button class="dark-mode-toggle" id="dark-mode-toggle" aria-label="Toggle dark mode" title="Toggle dark mode">
+      <svg class="icon-moon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+        <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path>
+      </svg>
+      <svg class="icon-sun" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+        <circle cx="12" cy="12" r="5"></circle>
+        <line x1="12" y1="1" x2="12" y2="3"></line>
+        <line x1="12" y1="21" x2="12" y2="23"></line>
+        <line x1="4.22" y1="4.22" x2="5.64" y2="5.64"></line>
+        <line x1="18.36" y1="18.36" x2="19.78" y2="19.78"></line>
+        <line x1="1" y1="12" x2="3" y2="12"></line>
+        <line x1="21" y1="12" x2="23" y2="12"></line>
+        <line x1="4.22" y1="19.78" x2="5.64" y2="18.36"></line>
+        <line x1="18.36" y1="5.64" x2="19.78" y2="4.22"></line>
+      </svg>
+    </button>
     <a data-href="https://www.linkedin.com/in/dev-dc" data-external="true" class="download-btn">
       <svg viewBox="0 0 24 24" fill="currentColor">
         <path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433c-1.144 0-2.063-.926-2.063-2.065 0-1.138.92-2.063 2.063-2.063 1.14 0 2.064.925 2.064 2.063 0 1.139-.925 2.065-2.064 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z"/>
@@ -324,6 +404,25 @@
     });
   };
   document.head.appendChild(script);
+})();
+
+// Dark mode toggle functionality
+(function() {
+  var toggle = document.getElementById('dark-mode-toggle');
+  var pdfPages = document.getElementById('pdf-pages');
+
+  // Check for saved preference
+  var isDark = localStorage.getItem('resume-dark-mode') === 'true';
+  if (isDark) {
+    toggle.classList.add('active');
+    pdfPages.classList.add('dark-mode');
+  }
+
+  toggle.addEventListener('click', function() {
+    toggle.classList.toggle('active');
+    pdfPages.classList.toggle('dark-mode');
+    localStorage.setItem('resume-dark-mode', pdfPages.classList.contains('dark-mode'));
+  });
 })();
 </script>
 

--- a/sw.js
+++ b/sw.js
@@ -1,6 +1,6 @@
 // Service Worker for SWU Calculator PWA
 // Version must be updated when deploying new code to bust cache
-const CACHE_VERSION = 'v68';
+const CACHE_VERSION = 'v69';
 const CACHE_NAME = `swu-calculator-${CACHE_VERSION}`;
 
 // Files to cache for offline use


### PR DESCRIPTION
## Summary
Added a dark mode toggle feature to the resume page that allows users to switch between light and dark themes for the PDF viewer. The preference is persisted using localStorage.

## Key Changes
- **Dark mode toggle button**: Added a circular icon-only button with moon/sun SVG icons that switches between light and dark modes
- **Dark mode styling**: Implemented CSS styles for dark mode that invert the PDF canvas and adjust text selection colors for better readability
- **Persistent preference**: User's dark mode preference is saved to localStorage and restored on page load
- **Responsive design**: Toggle button scales appropriately on mobile devices (max-width: 480px)
- **Accessibility**: Button includes proper aria-label and title attributes
- **Service worker cache**: Updated cache version from v68 to v69 to ensure users get the latest code

## Implementation Details
- The toggle button uses a glassmorphism design with backdrop blur effect and smooth transitions
- Dark mode applies `filter: invert(1) hue-rotate(180deg)` to PDF canvas for proper color inversion
- Button state is tracked with an `active` class that controls which icon (moon/sun) is displayed
- JavaScript IIFE pattern used to encapsulate dark mode functionality and avoid global scope pollution
- localStorage key: `resume-dark-mode` stores boolean preference as string

https://claude.ai/code/session_01KX59YCmPF1twYavVB6oXQq