### PR TITLE
Refine spacing and padding throughout UI components

### DIFF
--- a/pages/meet.html
+++ b/pages/meet.html
@@ -224,8 +224,8 @@
     height: calc(100svh - 56px);
     display: none;
     flex-direction: column;
-    padding: 0.75rem;
-    gap: 0.5rem;
+    padding: 0.25rem 0.5rem;
+    gap: 0.25rem;
     overflow: hidden;
     box-sizing: border-box;
   }
@@ -306,8 +306,8 @@
     flex: 1;
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(210px, 1fr));
-    gap: 0.75rem;
-    padding: 0.375rem;
+    gap: 0.5rem;
+    padding: 0.25rem;
     min-height: 0;
     overflow: hidden;
   }
@@ -408,8 +408,8 @@
     display: flex;
     justify-content: center;
     align-items: center;
-    gap: 0.75rem;
-    padding: 0.75rem;
+    gap: 0.5rem;
+    padding: 0.375rem;
     flex-wrap: wrap;
   }
 
@@ -507,17 +507,17 @@
   /* Sidebar */
   .sidebar {
     position: fixed;
-    right: 0.75rem;
-    top: calc(56px + 0.75rem);
+    right: 0.5rem;
+    top: calc(56px + 0.25rem);
     width: 240px;
-    height: calc(100vh - 56px - 1.5rem);
-    height: calc(100svh - 56px - 1.5rem);
+    height: calc(100vh - 56px - 0.5rem);
+    height: calc(100svh - 56px - 0.5rem);
     background: rgba(30, 30, 30, 0.9);
     backdrop-filter: blur(16px);
     -webkit-backdrop-filter: blur(16px);
     border: 1px solid rgba(255, 255, 255, 0.15);
     border-radius: 16px;
-    transform: translateX(calc(100% + 0.75rem));
+    transform: translateX(calc(100% + 0.5rem));
     transition: transform 0.3s ease;
     z-index: 100;
     display: flex;
@@ -1226,8 +1226,8 @@
 
   .view-toggle-bar {
     display: flex;
-    gap: 0.5rem;
-    margin-bottom: 0.5rem;
+    gap: 0.375rem;
+    margin-bottom: 0.25rem;
     justify-content: center;
   }
 

--- a/sw.js
+++ b/sw.js
@@ -1,6 +1,6 @@
 // Service Worker for SWU Calculator PWA
 // Version must be updated when deploying new code to bust cache
-const CACHE_VERSION = 'v69';
+const CACHE_VERSION = 'v70';
 const CACHE_NAME = `swu-calculator-${CACHE_VERSION}`;
 
 // Files to cache for offline use


### PR DESCRIPTION
## Summary
This PR reduces and standardizes spacing and padding values across the meet.html interface to create a more compact and refined layout. All changes are purely visual/stylistic with no functional modifications.

## Key Changes
- **Sidebar positioning**: Reduced right and top margins from `0.75rem` to `0.5rem` and `0.25rem` respectively
- **Sidebar height**: Decreased vertical padding from `1.5rem` to `0.5rem` for both viewport height calculations
- **Grid layout**: Reduced gap from `0.75rem` to `0.5rem` and padding from `0.375rem` to `0.25rem`
- **Control panels**: Adjusted padding and gaps across multiple components:
  - Main panel: `0.75rem` → `0.25rem 0.5rem` (padding), `0.5rem` → `0.25rem` (gap)
  - Action bar: `0.75rem` → `0.5rem` (gap), `0.75rem` → `0.375rem` (padding)
  - View toggle bar: `0.5rem` → `0.375rem` (gap), `0.5rem` → `0.25rem` (margin)
- **Cache version**: Bumped from `v69` to `v70` to invalidate cached assets

## Implementation Details
All spacing adjustments maintain visual hierarchy while reducing overall whitespace. The changes are consistent across similar component types and should improve space efficiency on the interface without compromising usability.

https://claude.ai/code/session_01XSf9esKnynzNntVkUgKB6F