### PR TITLE
Fix box-sizing on meet page and bump cache version

### DIFF
--- a/pages/meet.html
+++ b/pages/meet.html
@@ -17,6 +17,7 @@
     justify-content: center;
     padding: 1.5rem;
     gap: 1.5rem;
+    box-sizing: border-box;
   }
 
   .prejoin-card {

--- a/sw.js
+++ b/sw.js
@@ -1,6 +1,6 @@
 // Service Worker for SWU Calculator PWA
 // Version must be updated when deploying new code to bust cache
-const CACHE_VERSION = 'v71';
+const CACHE_VERSION = 'v72';
 const CACHE_NAME = `swu-calculator-${CACHE_VERSION}`;
 
 // Files to cache for offline use


### PR DESCRIPTION
## Summary
This PR includes a CSS fix for the meet page layout and updates the service worker cache version to ensure users receive the latest assets.

## Changes
- **pages/meet.html**: Added `box-sizing: border-box;` to the prejoin container to ensure padding is included in width/height calculations, preventing layout overflow issues
- **sw.js**: Bumped cache version from v71 to v72 to invalidate the service worker cache and force users to download updated assets

## Details
The `box-sizing: border-box;` property ensures that the element's total width and height include padding and borders, which is important for the prejoin container that uses flexbox with padding and gap properties. This prevents potential layout issues where content might overflow its container.

The cache version increment ensures the service worker will fetch fresh versions of all cached files on the next user visit.

https://claude.ai/code/session_01XFDEUWKKrPUrtGhX7fxvHT