### PR TITLE
Add meta tags for new pages and bump service worker cache

### DIFF
--- a/js/meta-manager.js
+++ b/js/meta-manager.js
@@ -68,6 +68,42 @@ const META_MAP = {
     desc: 'AI-powered chat to learn more about Benny Hartnett.',
     ogImage: BASE_OG_IMAGE,
     ogImageAlt: 'Chat with AI about Benny Hartnett'
+  },
+  'pages/app.html': {
+    title: 'Install App - Benny Hartnett',
+    desc: 'Install the SWU Calculator app for uranium enrichment calculations on iPhone and iPad.',
+    ogImage: 'https://bennyhartnett.com/assets/og-nuclear.png',
+    ogImageAlt: 'SWU Calculator - Uranium Enrichment App for iOS'
+  },
+  'pages/meet.html': {
+    title: 'Meet - Benny Hartnett',
+    desc: 'Video conferencing with screen sharing and real-time collaboration. No sign-up required.',
+    ogImage: BASE_OG_IMAGE,
+    ogImageAlt: 'Meet - Video Conferencing Tool'
+  },
+  'pages/clipboard.html': {
+    title: 'Clipboard - Benny Hartnett',
+    desc: 'Instant peer-to-peer sharing of text, images, and files using WebRTC. No server storage.',
+    ogImage: BASE_OG_IMAGE,
+    ogImageAlt: 'Clipboard - Peer-to-Peer File Sharing'
+  },
+  'pages/tools.html': {
+    title: 'Tools - Benny Hartnett',
+    desc: 'Apps and utilities including video conferencing, clipboard sharing, and calculators.',
+    ogImage: BASE_OG_IMAGE,
+    ogImageAlt: 'Tools - Apps and Utilities by Benny Hartnett'
+  },
+  'pages/resume.html': {
+    title: 'Resume - Benny Hartnett',
+    desc: 'Professional resume and background in software development, AI, and nuclear technology.',
+    ogImage: BASE_OG_IMAGE,
+    ogImageAlt: 'Resume - Benny Hartnett Professional Background'
+  },
+  'pages/terms.html': {
+    title: 'Terms - Benny Hartnett',
+    desc: 'Terms and privacy practices for bennyhartnett.com.',
+    ogImage: BASE_OG_IMAGE,
+    ogImageAlt: 'Terms and Privacy - Benny Hartnett'
   }
 };
 

--- a/sw.js
+++ b/sw.js
@@ -1,6 +1,6 @@
 // Service Worker for SWU Calculator PWA
 // Version must be updated when deploying new code to bust cache
-const CACHE_VERSION = 'v72';
+const CACHE_VERSION = 'v73';
 const CACHE_NAME = `swu-calculator-${CACHE_VERSION}`;
 
 // Files to cache for offline use


### PR DESCRIPTION
## Summary
Added SEO metadata for six new pages and updated the service worker cache version to ensure proper cache invalidation on deployment.

## Changes
- **Meta tags**: Added Open Graph and meta descriptions for the following pages:
  - `pages/app.html` - SWU Calculator app installation page
  - `pages/meet.html` - Video conferencing tool
  - `pages/clipboard.html` - Peer-to-peer file sharing utility
  - `pages/tools.html` - Tools and utilities hub
  - `pages/resume.html` - Professional resume
  - `pages/terms.html` - Terms and privacy page

- **Service Worker**: Bumped cache version from `v72` to `v73` to force cache refresh on deployment

## Implementation Details
- All new pages use descriptive titles following the "Page Name - Benny Hartnett" pattern
- Meta descriptions are concise and highlight key features of each tool
- Most pages use the base OG image, except `app.html` which uses a custom nuclear-themed image
- Alt text for OG images is descriptive for accessibility and SEO purposes

https://claude.ai/code/session_019vwzqijs9eCQVfUp5tNQgg