### PR TITLE
Fix padding inconsistencies in meet page layout

### DIFF
--- a/pages/meet.html
+++ b/pages/meet.html
@@ -225,7 +225,7 @@
     height: calc(100svh - 56px);
     display: none;
     flex-direction: column;
-    padding: 0.25rem 0.5rem;
+    padding: 0.25rem 0.5rem 0;
     gap: 0.25rem;
     overflow: hidden;
     box-sizing: border-box;
@@ -410,7 +410,7 @@
     justify-content: center;
     align-items: center;
     gap: 0.5rem;
-    padding: 0.375rem;
+    padding: 0.25rem 0.375rem;
     flex-wrap: wrap;
   }
 

--- a/sw.js
+++ b/sw.js
@@ -1,6 +1,6 @@
 // Service Worker for SWU Calculator PWA
 // Version must be updated when deploying new code to bust cache
-const CACHE_VERSION = 'v77';
+const CACHE_VERSION = 'v78';
 const CACHE_NAME = `swu-calculator-${CACHE_VERSION}`;
 
 // Files to cache for offline use


### PR DESCRIPTION
## Summary
Adjusted padding values in the meet page stylesheet to improve visual consistency and spacing alignment across UI components.

## Changes
- **Meet page container**: Modified bottom padding from `0.5rem` to `0` in the main flex container (line 228) to eliminate excess bottom spacing
- **Control buttons**: Updated padding from uniform `0.375rem` to `0.25rem 0.375rem` (horizontal/vertical) for better visual balance with wrapped button layouts
- **Cache version**: Bumped service worker cache version from `v77` to `v78` to ensure users receive the updated styles

## Details
These padding adjustments address spacing inconsistencies in the meet page layout, particularly:
- Removing unnecessary bottom padding that may have caused layout overflow
- Refining button padding to better accommodate flex-wrapped button groups with improved vertical spacing

The cache version increment ensures all users receive the updated stylesheet on next visit.

https://claude.ai/code/session_01DUzGFEurP7U3ps4br9xNVY