### PR TITLE
Fix clipboard container layout and center content

### DIFF
--- a/pages/clipboard.html
+++ b/pages/clipboard.html
@@ -8,10 +8,9 @@
   }
 
   .clipboard-container {
-    min-height: calc(100vh - 56px);
-    min-height: calc(100svh - 56px);
     display: flex;
     flex-direction: row;
+    justify-content: center;
     padding: 1.5rem;
     gap: 1.5rem;
   }
@@ -46,10 +45,8 @@
     border: 1px solid rgba(255, 255, 255, 0.1);
     border-radius: 14px;
     padding: 1.5rem;
-    flex: 1;
     display: flex;
     flex-direction: column;
-    min-height: 0;
   }
 
   .sidebar-header {

--- a/sw.js
+++ b/sw.js
@@ -1,6 +1,6 @@
 // Service Worker for SWU Calculator PWA
 // Version must be updated when deploying new code to bust cache
-const CACHE_VERSION = 'v79';
+const CACHE_VERSION = 'v80';
 const CACHE_NAME = `swu-calculator-${CACHE_VERSION}`;
 
 // Files to cache for offline use


### PR DESCRIPTION
## Summary
Refactored the clipboard container layout to properly center content and simplify the flexbox configuration for sidebar panels.

## Changes
- Removed fixed height constraints (`min-height: calc(100vh - 56px)` and `min-height: calc(100svh - 56px)`) from `.clipboard-container`
- Added `justify-content: center` to center child elements horizontally
- Removed `flex: 1` from `.sidebar-panel` to prevent unnecessary flex growth
- Removed `min-height: 0` from `.sidebar-panel` as it's no longer needed with the simplified layout
- Bumped service worker cache version from `v79` to `v80` to invalidate cached assets

## Implementation Details
The layout now relies on flexbox centering rather than viewport-height constraints, which provides better responsiveness and cleaner code. The sidebar panels will now size naturally based on their content rather than being forced to fill available space.

https://claude.ai/code/session_01CnXsUuYgBJudvKQoiTGBPY