### PR TITLE
Refactor clipboard UI: consolidate file/text sharing and add image preview

### DIFF
--- a/pages/clipboard.html
+++ b/pages/clipboard.html
@@ -11,7 +11,7 @@
     display: flex;
     flex-direction: row;
     justify-content: center;
-    padding: 1.5rem;
+    padding: 1rem;
     gap: 1.5rem;
   }
 
@@ -26,7 +26,7 @@
     backdrop-filter: blur(16px);
     border: 1px solid rgba(255, 255, 255, 0.1);
     border-radius: 14px;
-    padding: 1.5rem;
+    padding: 1rem;
     width: 100%;
     box-sizing: border-box;
   }
@@ -104,12 +104,12 @@
 
   .clipboard-header {
     text-align: center;
-    margin-bottom: 1.5rem;
+    margin-bottom: 0.75rem;
   }
 
   .clipboard-header h1 {
-    font-size: 1.5rem;
-    margin: 0 0 0.5rem 0;
+    font-size: 1.25rem;
+    margin: 0 0 0.25rem 0;
     display: flex;
     align-items: center;
     justify-content: center;
@@ -117,8 +117,8 @@
   }
 
   .clipboard-header h1 svg {
-    width: 28px;
-    height: 28px;
+    width: 22px;
+    height: 22px;
     color: #6366f1;
   }
 
@@ -132,8 +132,8 @@
   .room-info {
     background: rgba(0, 0, 0, 0.3);
     border-radius: 8px;
-    padding: 0.75rem;
-    margin-bottom: 1rem;
+    padding: 0.5rem 0.75rem;
+    margin-bottom: 0.75rem;
     display: flex;
     align-items: center;
     gap: 0.5rem;
@@ -217,10 +217,10 @@
     align-items: center;
     justify-content: center;
     gap: 0.5rem;
-    padding: 0.75rem;
+    padding: 0.5rem;
     border-radius: 8px;
-    font-size: 0.875rem;
-    margin-bottom: 1rem;
+    font-size: 0.8rem;
+    margin-bottom: 0.75rem;
   }
 
   .status-bar.waiting {
@@ -263,50 +263,16 @@
     display: block;
   }
 
-  .share-tabs {
-    display: flex;
-    gap: 0.25rem;
-    margin-bottom: 1rem;
-    background: rgba(0, 0, 0, 0.2);
-    padding: 0.25rem;
-    border-radius: 8px;
+  /* Text input with attachment */
+  .input-wrapper {
+    position: relative;
   }
 
-  .share-tab {
-    flex: 1;
-    padding: 0.5rem;
-    border: none;
-    background: transparent;
-    color: rgba(255, 255, 255, 0.6);
-    font-size: 0.8rem;
-    font-weight: 500;
-    border-radius: 6px;
-    cursor: pointer;
-    transition: all 0.2s ease;
-  }
-
-  .share-tab:hover {
-    color: white;
-  }
-
-  .share-tab.active {
-    background: rgba(255, 255, 255, 0.1);
-    color: white;
-  }
-
-  .tab-content {
-    display: none;
-  }
-
-  .tab-content.active {
-    display: block;
-  }
-
-  /* Text sharing */
   .text-input {
     width: 100%;
-    min-height: 120px;
-    padding: 1rem;
+    min-height: 80px;
+    padding: 0.75rem;
+    padding-bottom: 2.5rem;
     border-radius: 8px;
     border: 1px solid rgba(255, 255, 255, 0.2);
     background: rgba(0, 0, 0, 0.3);
@@ -326,42 +292,50 @@
     border-color: #6366f1;
   }
 
-  .send-btn {
-    width: 100%;
-    margin-top: 0.75rem;
-    padding: 0.75rem;
+  .input-actions {
+    position: absolute;
+    bottom: 0.5rem;
+    right: 0.5rem;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
   }
 
-  /* File sharing */
-  .drop-zone {
-    border: 2px dashed rgba(255, 255, 255, 0.2);
-    border-radius: 8px;
-    padding: 2rem;
-    text-align: center;
-    transition: all 0.2s ease;
+  .attach-btn {
+    width: 32px;
+    height: 32px;
+    padding: 0;
+    border: none;
+    background: rgba(255, 255, 255, 0.1);
+    border-radius: 6px;
     cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: all 0.2s ease;
   }
 
-  .drop-zone:hover,
-  .drop-zone.dragover {
-    border-color: #6366f1;
-    background: rgba(99, 102, 241, 0.1);
+  .attach-btn:hover {
+    background: rgba(255, 255, 255, 0.2);
   }
 
-  .drop-zone svg {
-    width: 48px;
-    height: 48px;
-    color: rgba(255, 255, 255, 0.4);
-    margin-bottom: 1rem;
+  .attach-btn svg {
+    width: 18px;
+    height: 18px;
+    color: rgba(255, 255, 255, 0.7);
   }
 
-  .drop-zone p {
-    margin: 0;
-    color: rgba(255, 255, 255, 0.6);
-    font-size: 0.875rem;
+  .send-btn {
+    padding: 0.5rem 1rem;
+    font-size: 0.8rem;
   }
 
-  .drop-zone input {
+  .send-btn svg {
+    width: 14px;
+    height: 14px;
+  }
+
+  .file-input-hidden {
     display: none;
   }
 
@@ -453,9 +427,66 @@
     color: rgba(255, 255, 255, 0.5);
   }
 
-  .copy-btn, .download-btn {
+  .copy-btn, .download-btn, .preview-btn {
     padding: 0.375rem 0.75rem;
     font-size: 0.75rem;
+  }
+
+  .file-actions {
+    display: flex;
+    gap: 0.5rem;
+  }
+
+  /* Image preview modal */
+  .preview-modal {
+    display: none;
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: rgba(0, 0, 0, 0.9);
+    z-index: 1000;
+    align-items: center;
+    justify-content: center;
+    padding: 1rem;
+  }
+
+  .preview-modal.active {
+    display: flex;
+  }
+
+  .preview-modal img {
+    max-width: 100%;
+    max-height: 100%;
+    object-fit: contain;
+    border-radius: 8px;
+  }
+
+  .preview-modal-close {
+    position: absolute;
+    top: 1rem;
+    right: 1rem;
+    width: 40px;
+    height: 40px;
+    border: none;
+    background: rgba(255, 255, 255, 0.1);
+    border-radius: 50%;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: all 0.2s ease;
+  }
+
+  .preview-modal-close:hover {
+    background: rgba(255, 255, 255, 0.2);
+  }
+
+  .preview-modal-close svg {
+    width: 24px;
+    height: 24px;
+    color: white;
   }
 
   /* Transfer progress */
@@ -564,36 +595,28 @@
       </div>
 
       <div class="share-section" id="shareSection">
-        <div class="share-tabs">
-          <button class="share-tab active" data-tab="text">Text</button>
-          <button class="share-tab" data-tab="file">Files</button>
-        </div>
-
-        <div class="tab-content active" id="textTab">
+        <div class="input-wrapper">
           <textarea class="text-input" id="textInput" placeholder="Type or paste text to share..."></textarea>
-          <button class="btn btn-primary send-btn" id="sendTextBtn">
-            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
-              <path stroke-linecap="round" stroke-linejoin="round" d="M6 12 3.269 3.125A59.769 59.769 0 0 1 21.485 12 59.768 59.768 0 0 1 3.27 20.875L5.999 12Zm0 0h7.5" />
-            </svg>
-            Send Text
-          </button>
+          <div class="input-actions">
+            <button class="attach-btn" id="attachBtn" title="Attach file">
+              <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" d="m18.375 12.739-7.693 7.693a4.5 4.5 0 0 1-6.364-6.364l10.94-10.94A3 3 0 1 1 19.5 7.372L8.552 18.32m.009-.01-.01.01m5.699-9.941-7.81 7.81a1.5 1.5 0 0 0 2.112 2.13" />
+              </svg>
+            </button>
+            <button class="btn btn-primary send-btn" id="sendTextBtn">
+              <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M6 12 3.269 3.125A59.769 59.769 0 0 1 21.485 12 59.768 59.768 0 0 1 3.27 20.875L5.999 12Zm0 0h7.5" />
+              </svg>
+              Send
+            </button>
+          </div>
+          <input type="file" id="fileInput" class="file-input-hidden" multiple>
         </div>
-
-        <div class="tab-content" id="fileTab">
-          <div class="drop-zone" id="dropZone">
-            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
-              <path stroke-linecap="round" stroke-linejoin="round" d="M3 16.5v2.25A2.25 2.25 0 0 0 5.25 21h13.5A2.25 2.25 0 0 0 21 18.75V16.5m-13.5-9L12 3m0 0 4.5 4.5M12 3v13.5" />
-            </svg>
-            <p>Drop files here or click to select</p>
-            <p style="font-size: 0.75rem; margin-top: 0.5rem; opacity: 0.6;">Images, documents, any file type</p>
-            <input type="file" id="fileInput" multiple>
+        <div class="transfer-progress" id="transferProgress">
+          <div class="progress-bar">
+            <div class="progress-fill" id="progressFill"></div>
           </div>
-          <div class="transfer-progress" id="transferProgress">
-            <div class="progress-bar">
-              <div class="progress-fill" id="progressFill"></div>
-            </div>
-            <div class="progress-text" id="progressText">Sending...</div>
-          </div>
+          <div class="progress-text" id="progressText">Sending...</div>
         </div>
       </div>
     </div>
@@ -621,6 +644,16 @@
   </div>
 </div>
 
+<!-- Preview modal -->
+<div class="preview-modal" id="previewModal">
+  <button class="preview-modal-close" id="previewModalClose">
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" d="M6 18 18 6M6 6l12 12" />
+    </svg>
+  </button>
+  <img id="previewModalImg" src="" alt="Preview">
+</div>
+
 <script type="module">
   // Import Trystero for serverless WebRTC (mesh network)
   import { joinRoom } from 'https://esm.sh/trystero@0.20.0/torrent';
@@ -631,7 +664,7 @@
   const shareSection = document.getElementById('shareSection');
   const textInput = document.getElementById('textInput');
   const sendTextBtn = document.getElementById('sendTextBtn');
-  const dropZone = document.getElementById('dropZone');
+  const attachBtn = document.getElementById('attachBtn');
   const fileInput = document.getElementById('fileInput');
   const transferProgress = document.getElementById('transferProgress');
   const progressFill = document.getElementById('progressFill');
@@ -639,9 +672,11 @@
   const receivedItems = document.getElementById('receivedItems');
   const sidebarEmpty = document.getElementById('sidebarEmpty');
   const messageCount = document.getElementById('messageCount');
-  const shareTabs = document.querySelectorAll('.share-tab');
   const roomInput = document.getElementById('roomInput');
   const newRoomBtn = document.getElementById('newRoomBtn');
+  const previewModal = document.getElementById('previewModal');
+  const previewModalImg = document.getElementById('previewModalImg');
+  const previewModalClose = document.getElementById('previewModalClose');
 
   // State
   const APP_ID = 'benny-clipboard-v1';
@@ -861,6 +896,15 @@
       img.src = data.content;
       item.appendChild(img);
 
+      const actionsDiv = document.createElement('div');
+      actionsDiv.className = 'file-actions';
+
+      const previewBtn = document.createElement('button');
+      previewBtn.className = 'btn btn-secondary preview-btn';
+      previewBtn.innerHTML = '<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M2.036 12.322a1.012 1.012 0 0 1 0-.639C3.423 7.51 7.36 4.5 12 4.5c4.638 0 8.573 3.007 9.963 7.178.07.207.07.431 0 .639C20.577 16.49 16.64 19.5 12 19.5c-4.638 0-8.573-3.007-9.963-7.178Z" /><path stroke-linecap="round" stroke-linejoin="round" d="M15 12a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z" /></svg> Preview';
+      previewBtn.onclick = () => showPreview(data.content);
+      actionsDiv.appendChild(previewBtn);
+
       const downloadBtn = document.createElement('button');
       downloadBtn.className = 'btn btn-secondary download-btn';
       downloadBtn.innerHTML = '<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M3 16.5v2.25A2.25 2.25 0 0 0 5.25 21h13.5A2.25 2.25 0 0 0 21 18.75V16.5M16.5 12 12 16.5m0 0L7.5 12m4.5 4.5V3" /></svg> Download';
@@ -870,7 +914,9 @@
         a.download = data.name || 'image.png';
         a.click();
       };
-      item.appendChild(downloadBtn);
+      actionsDiv.appendChild(downloadBtn);
+
+      item.appendChild(actionsDiv);
 
     } else if (data.type === 'file') {
       typeEl.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M19.5 14.25v-2.625a3.375 3.375 0 0 0-3.375-3.375h-1.5A1.125 1.125 0 0 1 13.5 7.125v-1.5a3.375 3.375 0 0 0-3.375-3.375H8.25m2.25 0H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 0 0-9-9Z" /></svg> File`;
@@ -976,37 +1022,28 @@
     }
   };
 
-  // Tab switching
-  shareTabs.forEach(tab => {
-    tab.onclick = () => {
-      shareTabs.forEach(t => t.classList.remove('active'));
-      tab.classList.add('active');
-      document.querySelectorAll('.tab-content').forEach(c => c.classList.remove('active'));
-      document.getElementById(tab.dataset.tab + 'Tab').classList.add('active');
-    };
-  });
-
-  // File handling
-  dropZone.onclick = () => fileInput.click();
+  // Attachment button
+  attachBtn.onclick = () => fileInput.click();
 
   fileInput.onchange = () => {
     Array.from(fileInput.files).forEach(sendFile);
     fileInput.value = '';
   };
 
-  dropZone.ondragover = (e) => {
-    e.preventDefault();
-    dropZone.classList.add('dragover');
+  // Preview modal
+  function showPreview(src) {
+    previewModalImg.src = src;
+    previewModal.classList.add('active');
+  }
+
+  previewModalClose.onclick = () => {
+    previewModal.classList.remove('active');
   };
 
-  dropZone.ondragleave = () => {
-    dropZone.classList.remove('dragover');
-  };
-
-  dropZone.ondrop = (e) => {
-    e.preventDefault();
-    dropZone.classList.remove('dragover');
-    Array.from(e.dataTransfer.files).forEach(sendFile);
+  previewModal.onclick = (e) => {
+    if (e.target === previewModal) {
+      previewModal.classList.remove('active');
+    }
   };
 
   // Paste handling

--- a/sw.js
+++ b/sw.js
@@ -1,6 +1,6 @@
 // Service Worker for SWU Calculator PWA
 // Version must be updated when deploying new code to bust cache
-const CACHE_VERSION = 'v80';
+const CACHE_VERSION = 'v81';
 const CACHE_NAME = `swu-calculator-${CACHE_VERSION}`;
 
 // Files to cache for offline use


### PR DESCRIPTION
## Summary
Redesigned the clipboard sharing interface to consolidate text and file inputs into a single unified input area, while reducing overall padding and spacing for a more compact layout. Added image preview functionality with a modal viewer.

## Key Changes

### UI/Layout Refinements
- Reduced padding throughout the interface (1.5rem → 1rem for containers, adjusted margins and padding in multiple sections)
- Decreased header font sizes and spacing (h1: 1.5rem → 1.25rem, icon: 28px → 22px)
- Tightened spacing in status bar, room info, and other components for a more compact design

### File/Text Input Consolidation
- Removed tab-based interface (`.share-tabs`, `.share-tab`, `.tab-content` classes removed)
- Merged file and text sharing into a single input area with inline action buttons
- Replaced drag-and-drop zone with a compact attachment button (`.attach-btn`) positioned in the text input area
- Simplified send button styling and reduced text input height (120px → 80px)
- Hidden file input with new `.file-input-hidden` class

### Image Preview Feature
- Added new `.preview-modal` component for full-screen image viewing
- Implemented preview button (`.preview-btn`) on image items
- Added modal close button with hover effects
- Modal supports clicking outside to close

### Code Organization
- Removed tab switching JavaScript logic
- Simplified file handling to use attachment button instead of drop zone
- Added `showPreview()` function and modal event handlers
- Updated service worker cache version (v80 → v81)

## Implementation Details
The new input wrapper uses absolute positioning for action buttons, allowing them to overlay the textarea without affecting layout. The preview modal uses `position: fixed` with `z-index: 1000` to ensure it appears above all other content. All spacing adjustments maintain visual hierarchy while reducing overall component size.

https://claude.ai/code/session_01LCV1MBSAZVdtW6Cg5af4vt