### PR TITLE
Adjust layout heights to account for bottom spacing

### DIFF
--- a/pages/meet.html
+++ b/pages/meet.html
@@ -9,8 +9,8 @@
 
   /* Pre-join Screen */
   .prejoin-container {
-    min-height: calc(100vh - 56px);
-    min-height: calc(100svh - 56px);
+    min-height: calc(100vh - 56px - 24px);
+    min-height: calc(100svh - 56px - 24px);
     display: flex;
     flex-direction: column;
     align-items: center;
@@ -221,8 +221,8 @@
 
   /* Meeting Room */
   .meet-container {
-    height: calc(100vh - 56px);
-    height: calc(100svh - 56px);
+    height: calc(100vh - 56px - 24px);
+    height: calc(100svh - 56px - 24px);
     display: none;
     flex-direction: column;
     padding: 0.25rem 0.5rem 0;
@@ -511,8 +511,8 @@
     right: 0.5rem;
     top: calc(56px + 0.25rem);
     width: 240px;
-    height: calc(100vh - 56px - 0.5rem);
-    height: calc(100svh - 56px - 0.5rem);
+    height: calc(100vh - 56px - 24px - 0.5rem);
+    height: calc(100svh - 56px - 24px - 0.5rem);
     background: rgba(30, 30, 30, 0.9);
     backdrop-filter: blur(16px);
     -webkit-backdrop-filter: blur(16px);

--- a/sw.js
+++ b/sw.js
@@ -1,6 +1,6 @@
 // Service Worker for SWU Calculator PWA
 // Version must be updated when deploying new code to bust cache
-const CACHE_VERSION = 'v82';
+const CACHE_VERSION = 'v83';
 const CACHE_NAME = `swu-calculator-${CACHE_VERSION}`;
 
 // Files to cache for offline use


### PR DESCRIPTION
## Summary
Adjusted CSS height calculations across the meet.html page to account for additional 24px bottom spacing, ensuring proper layout alignment and preventing overflow issues.

## Changes
- **Pre-join container**: Updated `min-height` calculations to subtract an additional 24px (`calc(100vh - 56px - 24px)` and `calc(100svh - 56px - 24px)`)
- **Meeting room container**: Updated `height` calculations to subtract an additional 24px (`calc(100vh - 56px - 24px)` and `calc(100svh - 56px - 24px)`)
- **Participants sidebar**: Updated `height` calculations to subtract an additional 24px (`calc(100vh - 56px - 24px - 0.5rem)` and `calc(100svh - 56px - 24px - 0.5rem)`)
- **Service Worker cache**: Bumped cache version from v82 to v83 to invalidate cached assets

## Implementation Details
The 24px adjustment appears to account for bottom UI spacing (likely a footer or bottom navigation bar). Both viewport height units (`100vh` and `100svh`) were updated consistently to maintain compatibility across different browsers and devices. The service worker version was incremented to ensure users receive the updated styles.

https://claude.ai/code/session_01Cg2QLEHu7KUQFAThyYbJ8k