### PR TITLE
Refactor tool card gradient effect to use text gradients

### DIFF
--- a/pages/tools.html
+++ b/pages/tools.html
@@ -51,64 +51,44 @@
     transform: translateY(-2px);
   }
 
-  /* Iridescent gradient layer */
-  .tool-card__gradient {
-    position: absolute;
-    inset: 0;
-    pointer-events: none;
-    z-index: 1;
-    opacity: 0;
-    mix-blend-mode: darken;
-    transform: translateZ(0);
-    transition: opacity 0.3s ease;
+  /* Iridescent text gradient */
+  .tool-card h2,
+  .tool-card p {
+    background: linear-gradient(90deg, white, white);
+    -webkit-background-clip: text;
+    background-clip: text;
+    -webkit-text-fill-color: transparent;
+    transition: background 0.3s ease;
   }
-  .tool-card:hover .tool-card__gradient {
-    opacity: 1;
+  .tool-card p {
+    background: linear-gradient(90deg, rgba(255, 255, 255, 0.7), rgba(255, 255, 255, 0.7));
+    -webkit-background-clip: text;
+    background-clip: text;
   }
-  .tool-card__gradient::before {
-    content: "";
-    position: absolute;
-    inset: -1px;
-    background:
-      radial-gradient(
-        400px circle at 20% 15%,
-        rgba(255, 255, 255, 0.18),
-        transparent 60%
-      ),
-      radial-gradient(
-        450px circle at 80% 85%,
-        rgba(255, 255, 255, 0.10),
-        transparent 55%
-      ),
-      conic-gradient(
-        from 180deg at 50% 50%,
-        rgba(0, 245, 255, 0.95),
-        rgba(99, 102, 241, 0.95),
-        rgba(168, 85, 247, 0.95),
-        rgba(236, 72, 153, 0.95),
-        rgba(245, 158, 11, 0.95),
-        rgba(34, 197, 94, 0.95),
-        rgba(0, 245, 255, 0.95)
-      );
-    background-size: 100% 100%, 100% 100%, 200% 200%;
-    background-position: 0% 0%, 0% 0%, 45% 55%;
-    filter: saturate(1.25) contrast(1.1);
-    animation: iridescent 10s linear infinite;
-    will-change: filter, background-position;
-    border-radius: 12px;
+  .tool-card:hover h2,
+  .tool-card:hover p {
+    background: conic-gradient(
+      from 180deg at 50% 50%,
+      rgba(0, 245, 255, 1),
+      rgba(99, 102, 241, 1),
+      rgba(168, 85, 247, 1),
+      rgba(236, 72, 153, 1),
+      rgba(245, 158, 11, 1),
+      rgba(34, 197, 94, 1),
+      rgba(0, 245, 255, 1)
+    );
+    background-size: 200% 200%;
+    -webkit-background-clip: text;
+    background-clip: text;
+    -webkit-text-fill-color: transparent;
+    animation: iridescent-text 4s linear infinite;
   }
-  @keyframes iridescent {
+  @keyframes iridescent-text {
     0% {
-      filter: saturate(1.25) contrast(1.1) hue-rotate(0deg);
-      background-position: 0% 0%, 0% 0%, 45% 55%;
-    }
-    50% {
-      filter: saturate(1.25) contrast(1.1) hue-rotate(180deg);
-      background-position: 0% 0%, 0% 0%, 55% 45%;
+      filter: hue-rotate(0deg);
     }
     100% {
-      filter: saturate(1.25) contrast(1.1) hue-rotate(360deg);
-      background-position: 0% 0%, 0% 0%, 45% 55%;
+      filter: hue-rotate(360deg);
     }
   }
 
@@ -249,7 +229,6 @@
 
   <div class="tools-grid">
     <a href="/meet" class="tool-card">
-      <div class="tool-card__gradient" aria-hidden="true"></div>
       <div class="tool-card__code" aria-hidden="true"></div>
       <div class="tool-header">
         <span class="tool-icon"><svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="m15.75 10.5 4.72-4.72a.75.75 0 0 1 1.28.53v11.38a.75.75 0 0 1-1.28.53l-4.72-4.72M4.5 18.75h9a2.25 2.25 0 0 0 2.25-2.25v-9a2.25 2.25 0 0 0-2.25-2.25h-9A2.25 2.25 0 0 0 2.25 7.5v9a2.25 2.25 0 0 0 2.25 2.25Z" /></svg></span>
@@ -260,7 +239,6 @@
     </a>
 
     <a href="/clipboard" class="tool-card">
-      <div class="tool-card__gradient" aria-hidden="true"></div>
       <div class="tool-card__code" aria-hidden="true"></div>
       <div class="tool-header">
         <span class="tool-icon"><svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M15.666 3.888A2.25 2.25 0 0 0 13.5 2.25h-3c-1.03 0-1.9.693-2.166 1.638m7.332 0c.055.194.084.4.084.612v0a.75.75 0 0 1-.75.75H9.75a.75.75 0 0 1-.75-.75v0c0-.212.03-.418.084-.612m7.332 0c.646.049 1.288.11 1.927.184 1.1.128 1.907 1.077 1.907 2.185V19.5a2.25 2.25 0 0 1-2.25 2.25H6.75A2.25 2.25 0 0 1 4.5 19.5V6.257c0-1.108.806-2.057 1.907-2.185a48.208 48.208 0 0 1 1.927-.184" /></svg></span>
@@ -271,7 +249,6 @@
     </a>
 
     <a href="/nuclear" class="tool-card">
-      <div class="tool-card__gradient" aria-hidden="true"></div>
       <div class="tool-card__code" aria-hidden="true"></div>
       <div class="tool-header">
         <span class="tool-icon"><svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M12 3v2.25m6.364.386-1.591 1.591M21 12h-2.25m-.386 6.364-1.591-1.591M12 18.75V21m-4.773-4.227-1.591 1.591M5.25 12H3m4.227-4.773L5.636 5.636M15.75 12a3.75 3.75 0 1 1-7.5 0 3.75 3.75 0 0 1 7.5 0Z" /></svg></span>
@@ -282,7 +259,6 @@
     </a>
 
     <a href="/chat" class="tool-card">
-      <div class="tool-card__gradient" aria-hidden="true"></div>
       <div class="tool-card__code" aria-hidden="true"></div>
       <div class="tool-header">
         <span class="tool-icon"><svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M8.625 12a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0Zm0 0H8.25m4.125 0a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0Zm0 0H12m4.125 0a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0Zm0 0h-.375M21 12c0 4.556-4.03 8.25-9 8.25a9.764 9.764 0 0 1-2.555-.337A5.972 5.972 0 0 1 5.41 20.97a5.969 5.969 0 0 1-.474-.065 4.48 4.48 0 0 0 .978-2.025c.09-.457-.133-.901-.467-1.226C3.93 16.178 3 14.189 3 12c0-4.556 4.03-8.25 9-8.25s9 3.694 9 8.25Z" /></svg></span>

--- a/sw.js
+++ b/sw.js
@@ -1,6 +1,6 @@
 // Service Worker for SWU Calculator PWA
 // Version must be updated when deploying new code to bust cache
-const CACHE_VERSION = 'v84';
+const CACHE_VERSION = 'v85';
 const CACHE_NAME = `swu-calculator-${CACHE_VERSION}`;
 
 // Files to cache for offline use


### PR DESCRIPTION
## Summary
Simplified the iridescent gradient effect on tool cards by moving from a complex layered background gradient to a more performant text-based gradient animation applied directly to headings and paragraphs.

## Key Changes
- **Removed complex gradient layer**: Eliminated the `.tool-card__gradient` pseudo-element with multiple radial and conic gradients, reducing DOM complexity
- **Implemented text gradient effect**: Applied `background-clip: text` technique to `h2` and `p` elements for a cleaner, more direct gradient application
- **Simplified animation**: Replaced the multi-step `iridescent` keyframe animation with a streamlined `iridescent-text` animation using only `hue-rotate` filter
- **Removed gradient divs**: Deleted 4 instances of `<div class="tool-card__gradient">` from the HTML markup
- **Updated cache version**: Bumped service worker cache from v84 to v85 to ensure fresh assets

## Implementation Details
- Text gradients use `conic-gradient` with the same color palette (cyan → indigo → purple → pink → amber → green → cyan)
- Hover state triggers the animated gradient with a 4-second animation cycle
- Default state shows white text with full opacity for headings and 70% opacity for paragraphs
- Maintains accessibility with `aria-hidden="true"` on remaining decorative elements
- Reduced animation complexity improves performance while maintaining visual appeal

https://claude.ai/code/session_01W3FHNtZaYhZ3EEKtfQrsR7