### PR TITLE
Fix text color fallbacks in tool cards and bump cache version

### DIFF
--- a/pages/tools.html
+++ b/pages/tools.html
@@ -54,6 +54,7 @@
   /* Iridescent text gradient */
   .tool-card h2,
   .tool-card p {
+    color: white !important;
     background: linear-gradient(90deg, white, white);
     -webkit-background-clip: text;
     background-clip: text;
@@ -61,6 +62,7 @@
     transition: background 0.3s ease;
   }
   .tool-card p {
+    color: rgba(255, 255, 255, 0.7) !important;
     background: linear-gradient(90deg, rgba(255, 255, 255, 0.7), rgba(255, 255, 255, 0.7));
     -webkit-background-clip: text;
     background-clip: text;

--- a/sw.js
+++ b/sw.js
@@ -1,6 +1,6 @@
 // Service Worker for SWU Calculator PWA
 // Version must be updated when deploying new code to bust cache
-const CACHE_VERSION = 'v85';
+const CACHE_VERSION = 'v86';
 const CACHE_NAME = `swu-calculator-${CACHE_VERSION}`;
 
 // Files to cache for offline use


### PR DESCRIPTION
## Summary
This PR adds explicit color fallbacks to tool card text elements and increments the service worker cache version to ensure users receive the latest assets.

## Changes
- **pages/tools.html**: Added `color` CSS properties as fallbacks for `.tool-card h2` and `.tool-card p` elements
  - `color: white !important;` for headings
  - `color: rgba(255, 255, 255, 0.7) !important;` for paragraphs
  - These fallbacks ensure text remains visible if the background-clip gradient fails to render properly
  
- **sw.js**: Bumped `CACHE_VERSION` from `v85` to `v86` to invalidate cached assets and force users to download the updated styles

## Implementation Details
The color fallbacks use `!important` to guarantee they take precedence, providing a safety net for browsers that don't fully support the `background-clip: text` technique. This ensures better cross-browser compatibility and accessibility while maintaining the intended gradient effect where supported.

https://claude.ai/code/session_014LEjuwhiABNQFJ9v66HMGG