### PR TITLE
Simplify tool card text styling and fix iridescent hover effect

### DIFF
--- a/pages/tools.html
+++ b/pages/tools.html
@@ -51,21 +51,12 @@
     transform: translateY(-2px);
   }
 
-  /* Iridescent text gradient */
-  .tool-card h2,
-  .tool-card p {
-    color: white !important;
-    background: linear-gradient(90deg, white, white);
-    -webkit-background-clip: text;
-    background-clip: text;
-    -webkit-text-fill-color: transparent;
-    transition: background 0.3s ease;
+  /* Tool card text - white by default, iridescent on hover */
+  .tool-card h2 {
+    color: white;
   }
   .tool-card p {
-    color: rgba(255, 255, 255, 0.7) !important;
-    background: linear-gradient(90deg, rgba(255, 255, 255, 0.7), rgba(255, 255, 255, 0.7));
-    -webkit-background-clip: text;
-    background-clip: text;
+    color: rgba(255, 255, 255, 0.7);
   }
   .tool-card:hover h2,
   .tool-card:hover p {
@@ -83,6 +74,7 @@
     -webkit-background-clip: text;
     background-clip: text;
     -webkit-text-fill-color: transparent;
+    color: transparent;
     animation: iridescent-text 4s linear infinite;
   }
   @keyframes iridescent-text {

--- a/sw.js
+++ b/sw.js
@@ -1,6 +1,6 @@
 // Service Worker for SWU Calculator PWA
 // Version must be updated when deploying new code to bust cache
-const CACHE_VERSION = 'v87';
+const CACHE_VERSION = 'v88';
 const CACHE_NAME = `swu-calculator-${CACHE_VERSION}`;
 
 // Files to cache for offline use


### PR DESCRIPTION
## Summary
Refactored the tool card text styling to improve clarity and fix the iridescent gradient effect on hover. The changes simplify the CSS by removing unnecessary gradient declarations for default states and properly implementing the iridescent animation only on hover.

## Key Changes
- **Simplified default text styling**: Removed complex gradient declarations from `.tool-card h2` and `.tool-card p` in favor of straightforward `color` properties
  - Headings now use solid white
  - Paragraphs now use semi-transparent white (0.7 opacity)
- **Fixed hover iridescent effect**: Moved gradient-based iridescent styling exclusively to the `:hover` state
- **Added `color: transparent`**: Ensures proper text rendering when the iridescent gradient is applied on hover
- **Updated service worker cache version**: Bumped from v87 to v88 to invalidate cached assets

## Implementation Details
The refactoring eliminates redundant CSS properties that were creating static gradients matching the text color (essentially no-ops). The iridescent animation now cleanly applies only on hover, providing a better visual experience without the complexity of managing gradients in multiple states.

https://claude.ai/code/session_01YPtgEAXKGrbwAG4Wt52sC9