### PR TITLE
Fix custom cursor positioning with explicit pixel offsets

### DIFF
--- a/js/smooth-cursor.js
+++ b/js/smooth-cursor.js
@@ -89,7 +89,8 @@
       z-index: 999999;
       pointer-events: none;
       will-change: transform;
-      transform: translate(-50%, -50%) scale(0.5);
+      transform-origin: 25px 5px;
+      transform: translate(-25px, -5px) scale(0.5);
     }
   `;
   document.head.appendChild(cursorStyle);
@@ -111,7 +112,7 @@
     const s = springScale.get();
 
     el.style.transform =
-      `translate3d(${x}px, ${y}px, 0) translate(-50%, -50%) rotate(${rot}deg) scale(${s * 0.5})`;
+      `translate3d(${x}px, ${y}px, 0) translate(-25px, -5px) rotate(${rot}deg) scale(${s * 0.5})`;
 
     if (doneX && doneY) {
       animating = false;
@@ -193,7 +194,7 @@
       springX.setPosition(e.clientX);
       springY.setPosition(e.clientY);
       el.style.transform =
-        `translate3d(${e.clientX}px, ${e.clientY}px, 0) translate(-50%, -50%) rotate(${springRot.get()}deg) scale(${springScale.get() * 0.5})`;
+        `translate3d(${e.clientX}px, ${e.clientY}px, 0) translate(-25px, -5px) rotate(${springRot.get()}deg) scale(${springScale.get() * 0.5})`;
     }
     el.style.opacity = '1';
   });

--- a/sw.js
+++ b/sw.js
@@ -1,6 +1,6 @@
 // Service Worker for SWU Calculator PWA
 // Version must be updated when deploying new code to bust cache
-const CACHE_VERSION = 'v89';
+const CACHE_VERSION = 'v90';
 const CACHE_NAME = `swu-calculator-${CACHE_VERSION}`;
 
 // Files to cache for offline use


### PR DESCRIPTION
## Summary
Updated the smooth cursor implementation to use explicit pixel-based positioning instead of percentage-based transforms, ensuring more predictable cursor alignment across different viewport sizes and zoom levels.

## Key Changes
- Replaced `translate(-50%, -50%)` with `translate(-25px, -5px)` in the cursor styling to use fixed pixel offsets that match the cursor dimensions (50x10px)
- Added `transform-origin: 25px 5px` to the initial cursor style for proper rotation behavior
- Updated all cursor transform calculations (3 locations) to use the new pixel-based translation values
- Bumped service worker cache version from v89 to v90 to invalidate cached assets

## Implementation Details
The cursor element is 50px wide and 10px tall. The previous percentage-based centering (`-50%, -50%`) was equivalent to `-25px, -5px`, but using explicit pixel values provides:
- Better cross-browser consistency
- More reliable positioning with CSS transforms
- Clearer intent in the code
- Proper alignment with the `transform-origin` property for rotation

https://claude.ai/code/session_01HgpiB5SFqvhqjRZQ8jBWxq