### PR TITLE
Remove iridescent hover effect from tool cards

### DIFF
--- a/pages/tools.html
+++ b/pages/tools.html
@@ -51,39 +51,11 @@
     transform: translateY(-2px);
   }
 
-  /* Tool card text - white by default, iridescent on hover */
   .tool-card h2 {
     color: white;
   }
   .tool-card p {
     color: rgba(255, 255, 255, 0.7);
-  }
-  .tool-card:hover h2,
-  .tool-card:hover p {
-    background: conic-gradient(
-      from 180deg at 50% 50%,
-      rgba(0, 245, 255, 1),
-      rgba(99, 102, 241, 1),
-      rgba(168, 85, 247, 1),
-      rgba(236, 72, 153, 1),
-      rgba(245, 158, 11, 1),
-      rgba(34, 197, 94, 1),
-      rgba(0, 245, 255, 1)
-    );
-    background-size: 200% 200%;
-    -webkit-background-clip: text;
-    background-clip: text;
-    -webkit-text-fill-color: transparent;
-    color: transparent;
-    animation: iridescent-text 4s linear infinite;
-  }
-  @keyframes iridescent-text {
-    0% {
-      filter: hue-rotate(0deg);
-    }
-    100% {
-      filter: hue-rotate(360deg);
-    }
   }
 
   /* Code glitch layer */

--- a/sw.js
+++ b/sw.js
@@ -1,6 +1,6 @@
 // Service Worker for SWU Calculator PWA
 // Version must be updated when deploying new code to bust cache
-const CACHE_VERSION = 'v90';
+const CACHE_VERSION = 'v91';
 const CACHE_NAME = `swu-calculator-${CACHE_VERSION}`;
 
 // Files to cache for offline use


### PR DESCRIPTION
## Summary
Removed the iridescent text animation effect that was applied to tool card headings and paragraphs on hover. This simplifies the styling while maintaining the base white text colors.

## Changes
- Removed `.tool-card:hover h2` and `.tool-card:hover p` hover state styles that applied a conic-gradient iridescent effect with animated hue rotation
- Removed the `@keyframes iridescent-text` animation definition
- Removed associated comment about iridescent hover behavior
- Updated service worker cache version from v90 to v91 to invalidate cached assets

## Details
The iridescent hover effect used a conic-gradient background with background-clip to create an animated color-shifting text effect. This has been completely removed, leaving tool card text in their default white and semi-transparent white states without any hover animation.

https://claude.ai/code/session_01BTMuXKgyx1k96KzA9NyimR