### PR TITLE
Update "Resume" to "Résumé" with accent throughout codebase

### DIFF
--- a/js/meta-manager.js
+++ b/js/meta-manager.js
@@ -82,10 +82,10 @@ const META_MAP = {
     ogImageAlt: 'Tools - Apps and Utilities by Benny Hartnett'
   },
   'pages/resume.html': {
-    title: 'Resume - Benny Hartnett',
-    desc: 'Professional resume and background in software development, AI, and nuclear technology.',
+    title: 'Résumé - Benny Hartnett',
+    desc: 'Professional résumé and background in software development, AI, and nuclear technology.',
     ogImage: BASE_OG_IMAGE,
-    ogImageAlt: 'Resume - Benny Hartnett Professional Background'
+    ogImageAlt: 'Résumé - Benny Hartnett Professional Background'
   },
   'pages/terms.html': {
     title: 'Terms - Benny Hartnett',

--- a/js/spa-router.js
+++ b/js/spa-router.js
@@ -145,7 +145,7 @@ function renderFallbackContent(url) {
       <ul class="link-list">\
         <li><a data-href="https://www.linkedin.com/in/dev-dc" data-external="true">LinkedIn</a></li>\
         <li><a data-href="https://github.com/bennyhartnett" data-external="true">GitHub</a></li>\
-        <li><a href="https://resume.bennyhartnett.com">Resume</a></li>\
+        <li><a href="https://resume.bennyhartnett.com">Résumé</a></li>\
         <li><a data-href="/nuclear">Nuclear</a></li>\
         <li><a data-href="/contact">Contact</a></li>\
       </ul>\

--- a/pages/home.html
+++ b/pages/home.html
@@ -179,7 +179,7 @@
 <ul class="link-list">
       <li><a data-href="https://github.com/bennyhartnett" data-external="true">GitHub</a></li>
   <li><a data-href="https://www.linkedin.com/in/dev-dc" data-external="true">LinkedIn</a></li>
-  <li><a href="https://resume.bennyhartnett.com">Resume</a></li>
+  <li><a href="https://resume.bennyhartnett.com">Résumé</a></li>
   <li><a data-href="/tools">Tools</a></li>
   <li><a data-href="/contact">Contact</a></li>
 </ul>

--- a/pages/resume.html
+++ b/pages/resume.html
@@ -321,7 +321,7 @@
         <polyline points="7 10 12 15 17 10"></polyline>
         <line x1="12" y1="15" x2="12" y2="3"></line>
       </svg>
-      Download My Resume
+      Download My Résumé
     </a>
     <a href="/contact" class="download-btn">
       <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">

--- a/pages/search.html
+++ b/pages/search.html
@@ -118,7 +118,7 @@
     { title: 'Tools', desc: 'Apps and utilities including video conferencing, clipboard sharing, and calculators.', url: 'https://tools.bennyhartnett.com/', keywords: 'tools apps utilities calculator clipboard meet' },
     { title: 'Contact', desc: 'Get in touch with Benny Hartnett.', url: 'https://contact.bennyhartnett.com/', keywords: 'contact email form' },
     { title: 'Chat', desc: 'AI-powered chat to learn more about Benny Hartnett.', url: 'https://chat.bennyhartnett.com/', keywords: 'chat ai assistant ask' },
-    { title: 'Resume', desc: 'Professional resume and background in software development, AI, and nuclear technology.', url: 'https://resume.bennyhartnett.com/', keywords: 'resume cv experience work history' },
+    { title: 'Résumé', desc: 'Professional résumé and background in software development, AI, and nuclear technology.', url: 'https://resume.bennyhartnett.com/', keywords: 'resume cv experience work history' },
     { title: 'Uranium Enrichment Calculators', desc: 'Lightweight browser-based tools for uranium enrichment scenarios: feed requirements, SWU demand, and optimum tails assay.', url: 'https://nuclear.bennyhartnett.com/', keywords: 'nuclear uranium enrichment swu calculator centrus' },
     { title: 'Meet', desc: 'Video conferencing with screen sharing and real-time collaboration. No sign-up required.', url: 'https://meet.bennyhartnett.com/', keywords: 'meet video call conferencing screen share' },
     { title: 'Clipboard', desc: 'Instant peer-to-peer sharing of text, images, and files using WebRTC. No server storage.', url: 'https://clipboard.bennyhartnett.com/', keywords: 'clipboard share text files webrtc peer' },

--- a/sw.js
+++ b/sw.js
@@ -1,6 +1,6 @@
 // Service Worker for SWU Calculator PWA
 // Version must be updated when deploying new code to bust cache
-const CACHE_VERSION = 'v96';
+const CACHE_VERSION = 'v97';
 const CACHE_NAME = `swu-calculator-${CACHE_VERSION}`;
 
 // Files to cache for offline use


### PR DESCRIPTION
## Summary
Updated all instances of "Resume" to "Résumé" (with accent) throughout the codebase for consistency and proper French spelling conventions.

## Key Changes
- Updated meta tags in `meta-manager.js` for the resume page (title, description, and og:image alt text)
- Updated link text in `spa-router.js` fallback content
- Updated link text in `pages/home.html`
- Updated button text in `pages/resume.html` ("Download My Résumé")
- Updated search index entry in `pages/search.html` (title and description)
- Incremented service worker cache version from v96 to v97 to ensure updated content is served

## Implementation Details
- All user-facing text references to "Resume" have been changed to "Résumé"
- The search keywords field was intentionally left unchanged to maintain backward compatibility with common search terms ("resume cv experience work history")
- Cache version bump ensures the service worker will fetch the latest version of all modified files

https://claude.ai/code/session_01UCMnjzV5pJVZ3kUii2GwfY