### PR TITLE
Fix touch scrolling on PDF text layer and update cache version

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -44,7 +44,6 @@ body {
   margin: 0;
   overflow-x: hidden;
   overflow-y: auto;
-  touch-action: manipulation;
   background: transparent;
   color: #fff;
 }

--- a/pages/resume.html
+++ b/pages/resume.html
@@ -182,6 +182,8 @@
     -ms-user-select: text;
     /* Ensure spans can receive pointer events for selection */
     pointer-events: auto;
+    /* Allow vertical scrolling through text layer on touch devices */
+    touch-action: pan-y;
   }
   .pdf-page .textLayer > span:not(:empty)::selection,
   .pdf-page .textLayer > span:not(:empty) *::selection {

--- a/sw.js
+++ b/sw.js
@@ -1,6 +1,6 @@
 // Service Worker for SWU Calculator PWA
 // Version must be updated when deploying new code to bust cache
-const CACHE_VERSION = 'v96';
+const CACHE_VERSION = 'v97';
 const CACHE_NAME = `swu-calculator-${CACHE_VERSION}`;
 
 // Files to cache for offline use


### PR DESCRIPTION
## Summary
This PR improves touch interaction handling on PDF documents and updates the service worker cache version to reflect the changes.

## Key Changes
- **PDF Text Layer Touch Scrolling**: Added `touch-action: pan-y` to the PDF text layer to allow vertical scrolling on touch devices while maintaining text selection capability
- **Removed Global Touch Action**: Removed `touch-action: manipulation` from the body element to prevent interference with touch gestures
- **Cache Version Bump**: Updated service worker cache version from v96 to v97 to invalidate cached assets

## Implementation Details
The changes address a touch interaction issue where users on touch devices couldn't scroll vertically through PDF documents. By explicitly allowing `pan-y` on the text layer while removing the restrictive `manipulation` value from the body, users can now scroll naturally while still being able to select text. The cache version increment ensures all clients receive the updated CSS and service worker logic.

https://claude.ai/code/session_01Td8bFJxfHFwa6RVrLjvJPQ