### PR TITLE
Add AI agent support and improve developer documentation

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,26 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "npm ci --ignore-scripts 2>/dev/null || true"
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Bash(git commit*)",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "npm test 2>&1 || echo 'WARN: Tests failed — review before committing'"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,21 @@
+# EditorConfig helps maintain consistent coding styles
+# https://editorconfig.org
+
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false
+
+[*.{json,yml,yaml}]
+indent_size = 2
+
+[Makefile]
+indent_style = tab

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,72 @@
+# Agent Instructions
+
+This file provides development instructions for AI coding agents (Cursor, Copilot, Windsurf, Cline, etc.). For Claude Code specifically, see `CLAUDE.md` which contains the same content plus Claude-specific hooks.
+
+## Quick Start
+
+```bash
+npm ci          # Install dependencies (vitest for testing)
+npm test        # Run unit tests (nuclear-math tests via vitest)
+```
+
+No build step is required — all frontend dependencies load from CDNs.
+
+## Code Style
+
+- 2 spaces indentation (no tabs)
+- Semicolons always
+- Single quotes in JS, double quotes in HTML attributes
+- LF line endings
+- Trailing newline on all files
+- Prefer `const` over `let`; avoid `var`
+- ES6 modules with `export function` / `export const`
+
+See `.editorconfig` for editor-enforced settings.
+
+## Testing
+
+Tests use Vitest and live in `nuclear/nuclear-math.test.js`.
+
+```bash
+npm test              # Run all tests once
+npm run test:watch    # Watch mode
+npm run test:coverage # With coverage
+```
+
+## Pre-Commit Checklist
+
+1. `npm test` passes
+2. If you modified HTML, JS, CSS, or assets: **increment `CACHE_VERSION`** in `sw.js`
+3. If you added a new page: update `sw.js` `STATIC_ASSETS` array
+4. If you modified `config/llms.txt` or `config/llms-full.txt`: update the "Last Updated" date
+
+## Architecture
+
+This site uses a hybrid routing system: Cloudflare Workers (edge) + client-side SPA.
+
+- `index.html` — SPA entry point, detects subdomain via `location.hostname`, loads `pages/*.html`
+- `workers/router.js` — Cloudflare Worker that redirects path URLs to subdomains
+- `sw.js` — Service worker with versioned cache for PWA offline support
+- `pages/*.html` — Content fragments (18 pages) loaded dynamically by the SPA
+- `nuclear/` — **Standalone** uranium enrichment calculator (intentionally separate from SPA)
+- `js/` — SPA modules: routing, meta tags, analytics, 3D wave background, cursor effects
+- `css/` — Stylesheets: main, components, animations, scrollbar
+
+### Routing Rules
+
+- Subdomain access: `contact.bennyhartnett.com` serves `pages/contact.html` via SPA
+- Path access: `bennyhartnett.com/contact` → 301 redirect to `contact.bennyhartnett.com`
+- Excluded paths: `/assets`, `/css`, `/js`, `/pages`, `/.well-known` bypass subdomain logic
+
+### DO NOT
+
+- Refactor the nuclear calculator (`nuclear/`) into the SPA — it is intentionally siloed with its own CSS (Tailwind), JS, and tests
+- Hardcode paths in navigation — use subdomain-aware link handling
+- Modify `workers/router.js` without understanding the `X-CF-Worker-Internal` redirect loop prevention
+
+### Adding a New Page
+
+1. Create `pages/newpage.html` (content fragment)
+2. Routing automatically supports `newpage.bennyhartnett.com` and `bennyhartnett.com/newpage`
+3. Update `sw.js` `STATIC_ASSETS` for offline caching
+4. Increment `CACHE_VERSION` in `sw.js`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,54 @@
 # Development Instructions
 
+## Quick Start
+
+```bash
+npm ci          # Install dependencies (vitest for testing)
+npm test        # Run unit tests (nuclear-math tests via vitest)
+npm run test:watch  # Run tests in watch mode
+```
+
+No build step is required — all frontend dependencies load from CDNs. To preview the site locally:
+
+```bash
+python3 -m http.server  # Serve at http://localhost:8000
+```
+
+## Code Style
+
+- **Indentation**: 2 spaces (no tabs)
+- **Semicolons**: Always
+- **Quotes**: Single quotes in JS, double quotes in HTML attributes
+- **Line endings**: LF (Unix)
+- **Trailing newline**: Yes, all files end with a newline
+- **Variables**: Prefer `const` over `let`; avoid `var`
+- **Modules**: ES6 modules with `export function` / `export const`
+
+See `.editorconfig` for editor-enforced settings.
+
+## Testing
+
+Tests use [Vitest](https://vitest.dev/) and live in `nuclear/nuclear-math.test.js`. They cover the uranium enrichment math functions (value function, SWU calculations, optimum tails assay, feed/product/waste calculations).
+
+```bash
+npm test              # Run all tests once
+npm run test:watch    # Run in watch mode
+npm run test:coverage # Run with coverage report
+```
+
+The test suite also runs in CI via `.github/workflows/test.yml` on every push and PR to `main`.
+
+## Pre-Commit Checklist
+
+Before committing changes, verify:
+
+1. `npm test` passes
+2. If you modified any HTML, JS, CSS, or assets: **increment `CACHE_VERSION`** in `sw.js` (e.g., `'v100'` → `'v101'`)
+3. If you added a new page: update `sw.js` `STATIC_ASSETS` array and follow the "Adding a New Page" section below
+4. If you modified `config/llms.txt` or `config/llms-full.txt`: update the "Last Updated" date at the bottom
+
+---
+
 ## Subdomain Routing Architecture
 
 This site uses a **hybrid routing system** with Cloudflare Workers + client-side SPA logic. **Read this before making routing changes.**

--- a/README.md
+++ b/README.md
@@ -1,71 +1,65 @@
 # bennyhartnett.com
 
-BennyHartnett.com is a minimalist static website built with plain HTML and a little JavaScript. The landing page uses [three.js](https://threejs.org/) to draw an animated wave background. Because every library loads from public CDNs, you can open the files directly in a browser with no build step required.
+Personal portfolio site with subdomain-based routing, a PWA shell, and an isolated uranium enrichment calculator.
 
-## Features
+## Architecture
 
-- **Animated wave background** &ndash; `index.html` draws a 3D wave using three.js and `SimplexNoise`. The waves react to mouse movement and smoothly cycle through colors.
-- **Responsive navigation** &ndash; On small screens, a hamburger button toggles the navigation links for easier mobile browsing.
-- **Modular pages** &ndash; Additional pages (`home.html`, `nuclear.html`, and `privacy.html`) are simple templates that can be edited or replaced.
-- **No build step** &ndash; All dependencies load from CDNs, so you can open the files directly or serve them with a simple HTTP server.
+- **Frontend**: Vanilla HTML/CSS/JS (ES6 modules, no bundler). Libraries load from CDNs.
+- **Routing**: Hybrid system — Cloudflare Workers handle edge routing, client-side SPA loads page fragments from `pages/`.
+- **Hosting**: GitHub Pages + Cloudflare Workers.
+- **PWA**: Service worker (`sw.js`) with versioned cache for offline support.
 
-## File Overview
-
-- `index.html` &ndash; Entry point that loads `home.html` via `fetch` and initializes the wave canvas.
-- `home.html` &ndash; Landing page with quick links such as email, GitHub, and LinkedIn.
-- `nuclear.html` &ndash; Placeholder summarizing nuclear projects.
-- `privacy.html` &ndash; Static privacy policy.
-- `sitemap.xml` &ndash; Search engine sitemap listing all pages.
-- `robots.txt` &ndash; Crawling directives that reference the sitemap.
-- `.vscode/launch.json` &ndash; VS Code configuration for launching `index.html`.
-- `README.md` &ndash; Project documentation.
+Each section of the site lives on its own subdomain (e.g., `contact.bennyhartnett.com`, `nuclear.bennyhartnett.com`). Path-based URLs (`bennyhartnett.com/contact`) redirect to the subdomain equivalent.
 
 ## Quick Start
 
-Clone or download the repository and start a simple HTTP server from the project root:
-
 ```bash
-python3 -m http.server
+npm ci                          # Install dev dependencies (vitest)
+python3 -m http.server          # Serve locally at http://localhost:8000
+npm test                        # Run unit tests
 ```
 
-Open `http://localhost:8000` in your browser. Because all scripts load from CDNs, no installation is required.
+No build step required.
 
-## Customization
+## Key Files
 
-- **Navigation links** &ndash; Edit the `<nav>` element in `index.html` to change the menu structure or link targets.
-- **Wave parameters** &ndash; Adjust `planeWidth`, `planeHeight`, color values, and the animation loop inside `index.html` to modify the effect.
-- **Fonts and styles** &ndash; Each page includes inline CSS that imports Google Fonts. Update these `<style>` blocks to match your branding.
-- **Adding content** &ndash; Replace the placeholder text in the individual HTML files or add new pages and update the navigation accordingly.
+| Path | Purpose |
+|------|---------|
+| `index.html` | SPA entry point — detects subdomain, loads page fragments |
+| `workers/router.js` | Cloudflare Worker for edge routing and subdomain redirects |
+| `sw.js` | Service worker with versioned cache (`CACHE_VERSION`) |
+| `pages/*.html` | Content fragments loaded by the SPA (18 pages) |
+| `nuclear/` | Standalone uranium enrichment calculator (separate app) |
+| `js/` | SPA modules: routing, meta tags, analytics, 3D background, cursor |
+| `css/` | Stylesheets: main, components, animations, scrollbar |
+| `config/` | PWA manifest, `llms.txt`, `humans.txt` |
+
+## Testing
+
+```bash
+npm test              # Run tests once (vitest)
+npm run test:watch    # Watch mode
+npm run test:coverage # With coverage
+```
+
+Tests live in `nuclear/nuclear-math.test.js` and cover the enrichment math functions. CI runs on every push/PR to `main` via `.github/workflows/test.yml`.
 
 ## Deployment
 
-The site is entirely static, so you can host it anywhere that serves HTML files. Copy the repository contents to your preferred platform&mdash;GitHub Pages, an S3 bucket, Netlify, and so on&mdash;and it will work without additional configuration.
+- **GitHub Pages**: Auto-deploys on push to `main` via `.github/workflows/gh-pages.yml`.
+- **Cloudflare Worker**: Auto-deploys when `workers/` or `wrangler.toml` change via `.github/workflows/deploy-worker.yml`.
 
-### GitHub Pages
+## AI Agent Support
 
-1. Ensure the `gh-pages.yml` workflow is enabled in the repository's **Actions** tab.
-2. In the repository **Settings** &rarr; **Pages**, choose **GitHub Actions** as the source.
-3. Push changes to the `main` branch and the workflow will automatically deploy the site.
+This repo is configured for AI coding agents:
 
-The repository includes a `.nojekyll` file so Pages serves the files as-is.
-
-## Dependencies
-
-The pages load the following libraries from public CDNs:
-
-- `three` and `SimplexNoise` for 3D rendering and noise calculations.
-- `es-module-shims` to support modern module syntax across browsers.
-
-## Contact
-
-- GitHub: [bennyhartnett](https://github.com/bennyhartnett)
-- LinkedIn: [dev-dc](https://www.linkedin.com/in/dev-dc)
- 
+- `CLAUDE.md` — Development instructions, architecture docs, and guardrails for Claude Code
+- `AGENTS.md` — Cross-tool agent instructions (Cursor, Copilot, Windsurf, etc.)
+- `.claude/settings.json` — Session-start hooks for Claude Code (auto-installs deps)
+- `.editorconfig` — Code style enforcement for all editors and agents
+- `config/llms.txt` / `config/llms-full.txt` — Structured content for LLM consumption
+- `.well-known/ai-plugin.json` — AI plugin metadata
 
 ## License
 
-This repository currently does not include a license file. If you plan to distribute or reuse the code, consider adding an appropriate license.
-
----
-
-Feel free to modify any file to suit your needs. The project is intentionally minimal so you can extend it in any direction.
+This repository does not include a license file. Contact me@bennyhartnett.com for reuse inquiries.

--- a/config/llms-full.txt
+++ b/config/llms-full.txt
@@ -315,4 +315,4 @@ For a condensed version, see: https://bennyhartnett.com/config/llms.txt
 
 ---
 
-*Last updated: 2026-01-21*
+*Last updated: 2026-02-23*

--- a/config/llms.txt
+++ b/config/llms.txt
@@ -84,4 +84,4 @@ This file (llms.txt) and llms-full.txt are the authoritative sources for LLM/AI 
 
 ## Last Updated
 
-2026-01-21
+2026-02-23

--- a/sw.js
+++ b/sw.js
@@ -1,6 +1,6 @@
 // Service Worker for SWU Calculator PWA
 // Version must be updated when deploying new code to bust cache
-const CACHE_VERSION = 'v100';
+const CACHE_VERSION = 'v101';
 const CACHE_NAME = `swu-calculator-${CACHE_VERSION}`;
 
 // Files to cache for offline use


### PR DESCRIPTION
## Summary

This PR enhances developer experience and AI agent integration by adding comprehensive development instructions, code style enforcement, and agent-specific guidance. It also updates project documentation to reflect the current architecture (subdomain routing, PWA, SPA with isolated nuclear calculator).

## Key Changes

- **New agent support files**:
  - `AGENTS.md` — Cross-tool agent instructions for Cursor, Copilot, Windsurf, Cline, etc.
  - `.claude/settings.json` — Claude Code session hooks for auto-installing deps and pre-commit test runs
  - `.editorconfig` — Enforced code style (2-space indent, LF line endings, trailing newlines)

- **Enhanced documentation**:
  - Rewrote `README.md` to document current architecture (subdomain routing, PWA, SPA, Cloudflare Workers)
  - Expanded `CLAUDE.md` with quick start, code style guide, testing instructions, and pre-commit checklist
  - Added "DO NOT" guardrails (e.g., don't refactor nuclear calculator into SPA)

- **Metadata updates**:
  - Updated `config/llms.txt` and `config/llms-full.txt` "Last Updated" dates (2026-02-23)
  - Incremented `CACHE_VERSION` in `sw.js` from `v100` to `v101`

## Implementation Details

- **Code style enforcement**: `.editorconfig` enforces 2-space indentation, LF line endings, and trailing newlines across all editors and AI agents
- **Pre-commit automation**: Claude Code's `.claude/settings.json` hooks auto-run `npm test` before git commits and auto-install deps on session start
- **Agent guardrails**: `AGENTS.md` and `CLAUDE.md` explicitly document the hybrid routing architecture and warn against refactoring the intentionally-isolated nuclear calculator
- **Testing**: Documentation clarifies that Vitest runs on `nuclear/nuclear-math.test.js` and is enforced in CI via `.github/workflows/test.yml`

No functional changes to the application itself — this is purely documentation and tooling configuration.

https://claude.ai/code/session_016RhfeCfEQ2VSQXgReidRkc