### PR TITLE
Add support for federalinnovations.com domain

### DIFF
--- a/index.html
+++ b/index.html
@@ -384,7 +384,7 @@
     window.initWaveBackground = initWaveBackground;
     // Skip wave background on nuclear subdomain (it has its own gradient background)
     const hostname = location.hostname;
-    const isNuclearSubdomain = hostname === 'nuclear.bennyhartnett.com';
+    const isNuclearSubdomain = hostname.startsWith('nuclear.');
     if (isNuclearSubdomain) {
       document.body.classList.add('nuclear-gradient-bg');
     } else {

--- a/js/spa-router.js
+++ b/js/spa-router.js
@@ -9,6 +9,23 @@ import { trackPageView } from './analytics.js';
 // Container element for content
 let container = null;
 
+// Supported root domains for subdomain routing
+const SUPPORTED_DOMAINS = ['bennyhartnett.com', 'federalinnovations.com'];
+
+/**
+ * Determine the root domain from the current hostname
+ * @returns {string} The matching root domain, defaults to bennyhartnett.com
+ */
+function getRootDomain() {
+  const hostname = location.hostname;
+  for (const domain of SUPPORTED_DOMAINS) {
+    if (hostname === domain || hostname === `www.${domain}` || hostname.endsWith(`.${domain}`)) {
+      return domain;
+    }
+  }
+  return SUPPORTED_DOMAINS[0];
+}
+
 // Prefetch cache for SPA page fragments
 const prefetchCache = new Map();
 
@@ -247,14 +264,14 @@ function handleLinkClick(e) {
   // Skip SPA handling for nuclear page - do full page navigation
   if (href === 'nuclear.html' || href === '/nuclear.html' || href === '/nuclear') {
     e.preventDefault();
-    window.location.href = 'https://nuclear.bennyhartnett.com';
+    window.location.href = `https://nuclear.${getRootDomain()}`;
     return;
   }
 
   // Handle home link - redirect to main domain
   if (href === '/' || href === '/home' || href === 'home.html' || href === '/home.html') {
     e.preventDefault();
-    window.location.href = 'https://bennyhartnett.com';
+    window.location.href = `https://${getRootDomain()}`;
     return;
   }
 
@@ -273,7 +290,7 @@ function handleLinkClick(e) {
       pageName = href.replace(/^pages\//, '').replace(/\.html$/, '');
     }
     // Redirect to subdomain
-    const targetUrl = 'https://' + pageName + '.bennyhartnett.com';
+    const targetUrl = `https://${pageName}.${getRootDomain()}`;
     window.location.href = targetUrl;
   }
 }
@@ -296,10 +313,10 @@ function handlePopState(e) {
 function getInitialPage() {
   let initial = 'pages/home.html';
   const hostname = location.hostname;
-  const rootDomain = 'bennyhartnett.com';
-  const isSubdomain = hostname.endsWith('.' + rootDomain) && hostname !== 'www.' + rootDomain;
+  const rootDomain = getRootDomain();
+  const isSub = hostname.endsWith('.' + rootDomain) && hostname !== 'www.' + rootDomain;
 
-  if (isSubdomain) {
+  if (isSub) {
     const subdomain = hostname.replace('.' + rootDomain, '');
     initial = subdomain === 'nuclear' ? 'nuclear.html' : 'pages/' + subdomain + '.html';
   } else {
@@ -330,7 +347,7 @@ function getInitialPage() {
  */
 function isSubdomain() {
   const hostname = location.hostname;
-  const rootDomain = 'bennyhartnett.com';
+  const rootDomain = getRootDomain();
   return hostname.endsWith('.' + rootDomain) && hostname !== 'www.' + rootDomain;
 }
 
@@ -352,12 +369,12 @@ export function initRouter() {
   if (title) {
     title.addEventListener('click', (e) => {
       e.preventDefault();
-      window.location.href = 'https://bennyhartnett.com';
+      window.location.href = `https://${getRootDomain()}`;
     });
     title.addEventListener('keydown', (e) => {
       if (e.key === 'Enter' || e.key === ' ') {
         e.preventDefault();
-        window.location.href = 'https://bennyhartnett.com';
+        window.location.href = `https://${getRootDomain()}`;
       }
     });
   }

--- a/sw.js
+++ b/sw.js
@@ -1,6 +1,6 @@
 // Service Worker for SWU Calculator PWA
 // Version must be updated when deploying new code to bust cache
-const CACHE_VERSION = 'v103';
+const CACHE_VERSION = 'v104';
 const CACHE_NAME = `swu-calculator-${CACHE_VERSION}`;
 
 // Files to cache for offline use

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -4,5 +4,7 @@ compatibility_date = "2025-12-01"
 
 routes = [
   { pattern = "bennyhartnett.com/*", zone_name = "bennyhartnett.com" },
-  { pattern = "*.bennyhartnett.com/*", zone_name = "bennyhartnett.com" }
+  { pattern = "*.bennyhartnett.com/*", zone_name = "bennyhartnett.com" },
+  { pattern = "federalinnovations.com/*", zone_name = "federalinnovations.com" },
+  { pattern = "*.federalinnovations.com/*", zone_name = "federalinnovations.com" }
 ]


### PR DESCRIPTION
## Summary
This PR extends the routing infrastructure to support multiple domains, adding `federalinnovations.com` alongside the existing `bennyhartnett.com`. The changes maintain backward compatibility while enabling the same subdomain-based routing logic across both domains.

## Key Changes

- **Worker Router (`workers/router.js`)**
  - Replaced hardcoded `ROOT_DOMAIN` constant with `SUPPORTED_DOMAINS` array
  - Added `getRootDomain()` function to dynamically determine the root domain from the request hostname
  - Updated all routing logic to use the determined root domain instead of hardcoded values
  - Added validation to pass through requests for unsupported domains

- **SPA Router (`js/spa-router.js`)**
  - Added `SUPPORTED_DOMAINS` array and `getRootDomain()` function for client-side domain detection
  - Updated all hardcoded domain references to use `getRootDomain()` dynamically
  - Ensures consistent behavior across both domains for subdomain navigation and home page redirects

- **Wrangler Configuration (`wrangler.toml`)**
  - Added route patterns for `federalinnovations.com` and `*.federalinnovations.com`
  - Configured appropriate zone names for DNS resolution

- **HTML & Service Worker**
  - Updated nuclear subdomain detection in `index.html` to use pattern matching instead of hardcoded domain
  - Bumped service worker cache version to `v104` to ensure fresh assets are loaded

## Implementation Details

- Both `getRootDomain()` functions (server and client) use identical matching logic: exact domain match, www subdomain match, or any subdomain match
- The server-side function returns `null` for unsupported domains, allowing graceful fallthrough
- The client-side function defaults to the first supported domain if no match is found
- All existing routing behavior (subdomain serving, path-to-subdomain redirects, special cases like nuclear) is preserved and now works for both domains

https://claude.ai/code/session_01VhDyx5aXwcqDLarMeY9Rnw