### PR TITLE
Refactor origin domain routing to use centralized constant

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -1,6 +1,6 @@
 // Service Worker for SWU Calculator PWA
 // Version must be updated when deploying new code to bust cache
-const CACHE_VERSION = 'v104';
+const CACHE_VERSION = 'v105';
 const CACHE_NAME = `swu-calculator-${CACHE_VERSION}`;
 
 // Files to cache for offline use


### PR DESCRIPTION
## Summary
This PR refactors the router to use a centralized `ORIGIN_DOMAIN` constant for all origin fetches, improving code maintainability and clarity around the distinction between the origin domain (GitHub Pages) and the root domain (user-facing domain).

## Key Changes
- Added `ORIGIN_DOMAIN` constant (`bennyhartnett.com`) to explicitly define where static content is hosted
- Created new `fetchFromOrigin()` helper function to standardize origin fetches with proper headers
- Updated all origin fetch calls to use the new constant and helper function instead of `rootDomain`
- Replaced direct `fetch(request)` calls with `fetchFromOrigin(request)` for consistency
- Updated comments to clarify the distinction between "origin domain" (GitHub Pages) and "root domain" (user-facing domain)
- Bumped service worker cache version from v104 to v105

## Implementation Details
- The `ORIGIN_DOMAIN` constant is now the single source of truth for where all static content originates
- The `fetchFromOrigin()` helper ensures all origin requests include the `INTERNAL_HEADER` to prevent redirect loops
- This change allows requests on any supported domain (e.g., `federalinnovations.com`) to fetch content from the origin domain while maintaining proper routing behavior
- Comments clarified that subdomain redirects still use `rootDomain` so users remain on their original domain

https://claude.ai/code/session_01GL3ykhCiEtn5RkJen9axzt