### PR TITLE
Fix mouse cursor tracking to always use latest position

### DIFF
--- a/js/smooth-cursor.js
+++ b/js/smooth-cursor.js
@@ -134,14 +134,22 @@
     }
   }
 
-  // --- Mouse handler (RAF-throttled) ---
-  let rafId = 0;
+  // --- Mouse handler (RAF-throttled, always captures latest position) ---
+  let pendingFrame = false;
+  let latestX = 0;
+  let latestY = 0;
+
   function onMouseMove(e) {
-    if (rafId) return;
-    rafId = requestAnimationFrame(() => {
-      rafId = 0;
-      const cx = e.clientX;
-      const cy = e.clientY;
+    // Always capture the latest position so we never use stale coordinates
+    latestX = e.clientX;
+    latestY = e.clientY;
+
+    if (pendingFrame) return;
+    pendingFrame = true;
+    requestAnimationFrame(() => {
+      pendingFrame = false;
+      const cx = latestX;
+      const cy = latestY;
       const now = Date.now();
       const dt = now - lastTime;
 

--- a/sw.js
+++ b/sw.js
@@ -1,6 +1,6 @@
 // Service Worker for SWU Calculator PWA
 // Version must be updated when deploying new code to bust cache
-const CACHE_VERSION = 'v105';
+const CACHE_VERSION = 'v106';
 const CACHE_NAME = `swu-calculator-${CACHE_VERSION}`;
 
 // Files to cache for offline use


### PR DESCRIPTION
## Summary
Fixed a race condition in the smooth cursor mouse handler where stale mouse coordinates could be used if multiple move events occurred before the RAF callback executed.

## Key Changes
- **Mouse handler refactoring**: Changed from storing a RAF ID to using a `pendingFrame` boolean flag for clearer intent
- **Latest position capture**: Introduced `latestX` and `latestY` variables that are always updated on every mouse move event, ensuring the RAF callback uses the most recent coordinates
- **Eliminated stale data**: Previously, if multiple `onMouseMove` events fired before the RAF callback executed, only the first event's coordinates would be used. Now the callback always uses the latest captured position
- **Cache version bump**: Updated service worker cache version from v105 to v106 to invalidate old caches

## Implementation Details
The fix ensures that even if the RAF callback is throttled and multiple mouse move events queue up, we always process the most recent mouse position rather than the first one that triggered the RAF. This provides smoother and more responsive cursor tracking, especially during rapid mouse movements.

https://claude.ai/code/session_01RFejvB1iEJuN86kkU6DFqQ