### PR TITLE
Add IDN subdomain alias support for internationalized domains

### DIFF
--- a/js/spa-router.js
+++ b/js/spa-router.js
@@ -12,6 +12,11 @@ let container = null;
 // Supported root domains for subdomain routing
 const SUPPORTED_DOMAINS = ['bennyhartnett.com', 'federalinnovations.com'];
 
+// IDN (punycode) subdomain aliases → canonical ASCII subdomain
+const IDN_ALIASES = {
+  'xn--rsum-bpad': 'resume',
+};
+
 /**
  * Determine the root domain from the current hostname
  * @returns {string} The matching root domain, defaults to bennyhartnett.com
@@ -317,7 +322,8 @@ function getInitialPage() {
   const isSub = hostname.endsWith('.' + rootDomain) && hostname !== 'www.' + rootDomain;
 
   if (isSub) {
-    const subdomain = hostname.replace('.' + rootDomain, '');
+    const rawSubdomain = hostname.replace('.' + rootDomain, '');
+    const subdomain = IDN_ALIASES[rawSubdomain] || rawSubdomain;
     initial = subdomain === 'nuclear' ? 'nuclear.html' : 'pages/' + subdomain + '.html';
   } else {
     // Check for SPA redirect from 404.html

--- a/sw.js
+++ b/sw.js
@@ -1,6 +1,6 @@
 // Service Worker for SWU Calculator PWA
 // Version must be updated when deploying new code to bust cache
-const CACHE_VERSION = 'v106';
+const CACHE_VERSION = 'v107';
 const CACHE_NAME = `swu-calculator-${CACHE_VERSION}`;
 
 // Files to cache for offline use

--- a/workers/router.js
+++ b/workers/router.js
@@ -12,6 +12,12 @@ const SUPPORTED_DOMAINS = ['bennyhartnett.com', 'federalinnovations.com'];
 // Header to mark internal origin fetches (prevents redirect loops)
 const INTERNAL_HEADER = 'X-CF-Worker-Internal';
 
+// IDN (punycode) subdomain aliases → canonical ASCII subdomain
+// e.g., résumé.bennyhartnett.com (xn--rsum-bpad) → resume.bennyhartnett.com
+const IDN_ALIASES = {
+  'xn--rsum-bpad': 'resume',
+};
+
 // Paths that should NOT be treated as subdomains (static assets, etc.)
 const EXCLUDED_PATHS = [
   'index.html',
@@ -99,6 +105,11 @@ async function handleSubdomain(request, url, hostname, rootDomain) {
   // Redirect thank-you subdomain to sent subdomain (at root)
   if (subdomain === 'thank-you') {
     return Response.redirect(`https://sent.${rootDomain}/`, 301);
+  }
+
+  // Redirect IDN (punycode) subdomains to their canonical ASCII equivalents
+  if (IDN_ALIASES[subdomain]) {
+    return Response.redirect(`https://${IDN_ALIASES[subdomain]}.${rootDomain}/`, 301);
   }
 
   // Nuclear subdomain (and centrus alias): serve nuclear.html directly (it's a standalone page, not an SPA fragment)


### PR DESCRIPTION
## Summary
Add support for Internationalized Domain Names (IDN) by implementing punycode subdomain aliases that redirect to their canonical ASCII equivalents. This allows users accessing subdomains with non-ASCII characters (e.g., `résumé.bennyhartnett.com`) to be seamlessly redirected to the standard ASCII version (`resume.bennyhartnett.com`).

## Key Changes
- **workers/router.js**: Added `IDN_ALIASES` mapping object to translate punycode subdomains to canonical ASCII subdomains, with redirect logic in `handleSubdomain()` function
- **js/spa-router.js**: Added matching `IDN_ALIASES` mapping and updated `getInitialPage()` to resolve punycode subdomains to their canonical forms before page routing
- **sw.js**: Incremented service worker cache version from v106 to v107 to ensure clients receive updated routing logic

## Implementation Details
- The `IDN_ALIASES` object maps punycode-encoded subdomains (e.g., `xn--rsum-bpad` for "résumé") to their ASCII equivalents (e.g., `resume`)
- Server-side routing performs a 301 permanent redirect for punycode subdomains, ensuring proper SEO and canonical URL handling
- Client-side SPA router resolves aliases transparently without redirects, maintaining seamless user experience for direct page loads
- Both implementations use the same alias mapping to ensure consistency across server and client routing

https://claude.ai/code/session_01FeC13wsHpQPDNAiD8QA4AA