### PR TITLE
Use IDN (punycode) URLs for résumé subdomain

### DIFF
--- a/js/spa-router.js
+++ b/js/spa-router.js
@@ -12,9 +12,14 @@ let container = null;
 // Supported root domains for subdomain routing
 const SUPPORTED_DOMAINS = ['bennyhartnett.com', 'federalinnovations.com'];
 
-// IDN (punycode) subdomain aliases → canonical ASCII subdomain
+// IDN (punycode) subdomain → page name (for resolving which page to load)
 const IDN_ALIASES = {
   'xn--rsum-bpad': 'resume',
+};
+
+// ASCII subdomain → canonical IDN (punycode) subdomain (for link generation)
+const ASCII_TO_IDN = {
+  'resume': 'xn--rsum-bpad',
 };
 
 /**
@@ -167,7 +172,7 @@ function renderFallbackContent(url) {
       <ul class="link-list">\
         <li><a data-href="https://www.linkedin.com/in/dev-dc" data-external="true">LinkedIn</a></li>\
         <li><a data-href="https://github.com/bennyhartnett" data-external="true">GitHub</a></li>\
-        <li><a href="https://resume.bennyhartnett.com">Résumé</a></li>\
+        <li><a href="https://xn--rsum-bpad.bennyhartnett.com">Résumé</a></li>\
         <li><a data-href="/nuclear">Nuclear</a></li>\
         <li><a data-href="/contact">Contact</a></li>\
       </ul>\
@@ -294,8 +299,9 @@ function handleLinkClick(e) {
     } else {
       pageName = href.replace(/^pages\//, '').replace(/\.html$/, '');
     }
-    // Redirect to subdomain
-    const targetUrl = `https://${pageName}.${getRootDomain()}`;
+    // Redirect to subdomain (use IDN version if available)
+    const subdomain = ASCII_TO_IDN[pageName] || pageName;
+    const targetUrl = `https://${subdomain}.${getRootDomain()}`;
     window.location.href = targetUrl;
   }
 }

--- a/pages/download.html
+++ b/pages/download.html
@@ -66,7 +66,7 @@
     setTimeout(function() {
       window.close();
       // Fallback: redirect to full URL to avoid loop on same subdomain
-      window.location.href = 'https://resume.bennyhartnett.com';
+      window.location.href = 'https://xn--rsum-bpad.bennyhartnett.com';
     }, 500);
   }, 300);
 })();

--- a/pages/home.html
+++ b/pages/home.html
@@ -179,7 +179,7 @@
 <ul class="link-list">
       <li><a data-href="https://github.com/bennyhartnett" data-external="true">GitHub</a></li>
   <li><a data-href="https://www.linkedin.com/in/dev-dc" data-external="true">LinkedIn</a></li>
-  <li><a href="https://resume.bennyhartnett.com">Résumé</a></li>
+  <li><a href="https://xn--rsum-bpad.bennyhartnett.com">Résumé</a></li>
   <li><a data-href="/tools">Tools</a></li>
   <li><a data-href="/contact">Contact</a></li>
 </ul>

--- a/pages/search.html
+++ b/pages/search.html
@@ -118,7 +118,7 @@
     { title: 'Tools', desc: 'Apps and utilities including video conferencing, clipboard sharing, and calculators.', url: 'https://tools.bennyhartnett.com/', keywords: 'tools apps utilities calculator clipboard meet' },
     { title: 'Contact', desc: 'Get in touch with Benny Hartnett.', url: 'https://contact.bennyhartnett.com/', keywords: 'contact email form' },
     { title: 'Chat', desc: 'AI-powered chat to learn more about Benny Hartnett.', url: 'https://chat.bennyhartnett.com/', keywords: 'chat ai assistant ask' },
-    { title: 'Résumé', desc: 'Professional résumé and background in software development, AI, and nuclear technology.', url: 'https://resume.bennyhartnett.com/', keywords: 'resume cv experience work history' },
+    { title: 'Résumé', desc: 'Professional résumé and background in software development, AI, and nuclear technology.', url: 'https://xn--rsum-bpad.bennyhartnett.com/', keywords: 'resume cv experience work history' },
     { title: 'Uranium Enrichment Calculators', desc: 'Lightweight browser-based tools for uranium enrichment scenarios: feed requirements, SWU demand, and optimum tails assay.', url: 'https://nuclear.bennyhartnett.com/', keywords: 'nuclear uranium enrichment swu calculator centrus' },
     { title: 'Meet', desc: 'Video conferencing with screen sharing and real-time collaboration. No sign-up required.', url: 'https://meet.bennyhartnett.com/', keywords: 'meet video call conferencing screen share' },
     { title: 'Clipboard', desc: 'Instant peer-to-peer sharing of text, images, and files using WebRTC. No server storage.', url: 'https://clipboard.bennyhartnett.com/', keywords: 'clipboard share text files webrtc peer' },

--- a/sw.js
+++ b/sw.js
@@ -1,6 +1,6 @@
 // Service Worker for SWU Calculator PWA
 // Version must be updated when deploying new code to bust cache
-const CACHE_VERSION = 'v107';
+const CACHE_VERSION = 'v108';
 const CACHE_NAME = `swu-calculator-${CACHE_VERSION}`;
 
 // Files to cache for offline use

--- a/workers/router.js
+++ b/workers/router.js
@@ -12,10 +12,10 @@ const SUPPORTED_DOMAINS = ['bennyhartnett.com', 'federalinnovations.com'];
 // Header to mark internal origin fetches (prevents redirect loops)
 const INTERNAL_HEADER = 'X-CF-Worker-Internal';
 
-// IDN (punycode) subdomain aliases → canonical ASCII subdomain
-// e.g., résumé.bennyhartnett.com (xn--rsum-bpad) → resume.bennyhartnett.com
-const IDN_ALIASES = {
-  'xn--rsum-bpad': 'resume',
+// ASCII subdomain → canonical IDN (punycode) subdomain
+// e.g., resume.bennyhartnett.com → résumé.bennyhartnett.com (xn--rsum-bpad)
+const ASCII_TO_IDN = {
+  'resume': 'xn--rsum-bpad',
 };
 
 // Paths that should NOT be treated as subdomains (static assets, etc.)
@@ -107,9 +107,9 @@ async function handleSubdomain(request, url, hostname, rootDomain) {
     return Response.redirect(`https://sent.${rootDomain}/`, 301);
   }
 
-  // Redirect IDN (punycode) subdomains to their canonical ASCII equivalents
-  if (IDN_ALIASES[subdomain]) {
-    return Response.redirect(`https://${IDN_ALIASES[subdomain]}.${rootDomain}/`, 301);
+  // Redirect ASCII aliases to their canonical IDN (punycode) subdomains
+  if (ASCII_TO_IDN[subdomain]) {
+    return Response.redirect(`https://${ASCII_TO_IDN[subdomain]}.${rootDomain}/`, 301);
   }
 
   // Nuclear subdomain (and centrus alias): serve nuclear.html directly (it's a standalone page, not an SPA fragment)
@@ -173,9 +173,10 @@ async function handleMainDomain(request, url, rootDomain) {
     return fetch(request);
   }
 
-  // Redirect to subdomain
+  // Redirect to subdomain (use IDN version if available)
+  const targetSubdomain = ASCII_TO_IDN[firstSegment] || firstSegment;
   const newUrl = new URL(url);
-  newUrl.hostname = `${firstSegment}.${rootDomain}`;
+  newUrl.hostname = `${targetSubdomain}.${rootDomain}`;
 
   // Remove the first path segment since it's now the subdomain
   pathParts.shift();


### PR DESCRIPTION
## Summary
This PR updates the application to use the internationalized domain name (IDN) version of the résumé subdomain (`xn--rsum-bpad.bennyhartnett.com`) in all user-facing links and redirects, while maintaining backward compatibility with ASCII aliases.

## Key Changes

- **Router logic refactoring**: Inverted the subdomain alias mapping in `workers/router.js`
  - Changed `IDN_ALIASES` (punycode → ASCII) to `ASCII_TO_IDN` (ASCII → punycode)
  - Updated redirect logic to convert ASCII subdomain requests to their canonical IDN equivalents
  - This ensures users accessing `resume.bennyhartnett.com` are redirected to the proper IDN URL

- **SPA router updates** in `js/spa-router.js`
  - Added `ASCII_TO_IDN` mapping for link generation
  - Kept `IDN_ALIASES` for page name resolution (punycode → page name)
  - Updated link click handler to use IDN subdomains when available

- **User-facing URL updates**: Changed all hardcoded résumé links across the application
  - `pages/home.html`: Updated résumé link in navigation
  - `pages/search.html`: Updated search index entry for résumé
  - `pages/download.html`: Updated fallback redirect URL
  - All now point to `https://xn--rsum-bpad.bennyhartnett.com`

- **Cache invalidation**: Bumped service worker cache version from v107 to v108

## Implementation Details

The change maintains backward compatibility by:
1. Accepting requests to `resume.bennyhartnett.com` at the router level
2. Redirecting them to the canonical `xn--rsum-bpad.bennyhartnett.com` URL
3. Using the IDN URL in all generated links to ensure consistent user experience

This approach allows the application to properly display the French accented character (é) in the résumé subdomain while maintaining ASCII fallback support.

https://claude.ai/code/session_01X52sykvUZREubfJXrZY3zT