### PR TITLE
Change link hover color from wave-color to white

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -123,7 +123,7 @@ select {
 }
 
 .content a:hover {
-  color: var(--wave-color);
+  color: white;
 }
 
 /* Wave Canvas Background */

--- a/pages/home.html
+++ b/pages/home.html
@@ -64,7 +64,7 @@
   }
 
   .link-list a:hover {
-    color: var(--wave-color);
+    color: white;
   }
   .link-list a:focus-visible {
     outline: 2px solid var(--wave-color);

--- a/sw.js
+++ b/sw.js
@@ -1,6 +1,6 @@
 // Service Worker for SWU Calculator PWA
 // Version must be updated when deploying new code to bust cache
-const CACHE_VERSION = 'v114';
+const CACHE_VERSION = 'v115';
 const CACHE_NAME = `swu-calculator-${CACHE_VERSION}`;
 
 // Files to cache for offline use


### PR DESCRIPTION
## Summary
Updated the hover color for links across the application from the CSS variable `--wave-color` to white for improved visual consistency and contrast.

## Changes
- **css/main.css**: Changed `.content a:hover` color from `var(--wave-color)` to `white`
- **pages/home.html**: Changed `.link-list a:hover` color from `var(--wave-color)` to `white`
- **sw.js**: Bumped cache version from `v114` to `v115` to invalidate cached assets

## Details
This change standardizes the link hover state styling to use white instead of the wave-color variable, likely improving readability and providing better visual feedback on hover interactions. The service worker cache version has been incremented to ensure users receive the updated styles.

https://claude.ai/code/session_017RXRifwmYf8cY7TQ2Bvqzj