### PR TITLE
Refine PDF dark mode styling and opacity adjustments

### DIFF
--- a/pages/resume.html
+++ b/pages/resume.html
@@ -101,10 +101,10 @@
   }
   /* Dark mode styles for PDF */
   .pdf-pages.dark-mode {
-    background: rgba(255, 255, 255, 0.1);
+    background: rgba(255, 255, 255, 0.06);
     backdrop-filter: blur(12px);
     -webkit-backdrop-filter: blur(12px);
-    border: 1px solid rgba(255, 255, 255, 0.2);
+    border: 1px solid rgba(255, 255, 255, 0.15);
     border-radius: 12px;
     box-shadow:
       0 8px 32px rgba(0, 0, 0, 0.3),
@@ -112,6 +112,7 @@
   }
   .pdf-pages.dark-mode .pdf-page canvas {
     filter: invert(1) hue-rotate(180deg);
+    opacity: 0.82;
   }
   .pdf-pages.dark-mode .pdf-page .textLayer ::selection {
     background: rgba(100, 150, 255, 0.5);
@@ -135,7 +136,7 @@
   }
   .pdf-pages {
     box-shadow: 0 2px 10px rgba(0,0,0,0.3);
-    background: rgba(255, 255, 255, 0.92);
+    background: rgba(255, 255, 255, 0.75);
   }
   .pdf-page {
     position: relative;
@@ -145,6 +146,7 @@
     background: transparent;
     position: relative;
     z-index: 1;
+    opacity: 0.88;
   }
   /* Text layer for selectable/searchable text */
   .pdf-page .textLayer {

--- a/sw.js
+++ b/sw.js
@@ -1,6 +1,6 @@
 // Service Worker for SWU Calculator PWA
 // Version must be updated when deploying new code to bust cache
-const CACHE_VERSION = 'v116';
+const CACHE_VERSION = 'v117';
 const CACHE_NAME = `swu-calculator-${CACHE_VERSION}`;
 
 // Files to cache for offline use


### PR DESCRIPTION
## Summary
This PR improves the visual appearance of PDF rendering in dark mode by adjusting transparency levels and opacity values for better readability and contrast.

## Key Changes
- **Dark mode background**: Reduced opacity from `0.1` to `0.06` for a more subtle glassmorphism effect
- **Dark mode border**: Decreased opacity from `0.2` to `0.15` for softer border visibility
- **Canvas filter opacity**: Added `opacity: 0.82` to the inverted canvas to prevent over-brightening in dark mode
- **Light mode background**: Adjusted from `0.92` to `0.75` for improved visual hierarchy
- **Text layer opacity**: Added `opacity: 0.88` to the text layer for better text rendering
- **Cache version**: Bumped from `v116` to `v117` to invalidate cached assets

## Implementation Details
These changes work together to create a more balanced visual experience when viewing PDFs in dark mode. The reduced background and border opacity create a more refined glassmorphic effect, while the canvas and text layer opacity adjustments prevent the inverted colors from appearing too bright or washed out. The light mode background adjustment provides better contrast and visual separation.

https://claude.ai/code/session_01XkiKgNA9eW43xrBnnR4RAd