### PR TITLE
Refine PDF viewer styling with glassmorphism and opacity adjustments

### DIFF
--- a/pages/resume.html
+++ b/pages/resume.html
@@ -101,10 +101,10 @@
   }
   /* Dark mode styles for PDF */
   .pdf-pages.dark-mode {
-    background: rgba(255, 255, 255, 0.1);
+    background: rgba(255, 255, 255, 0.06);
     backdrop-filter: blur(12px);
     -webkit-backdrop-filter: blur(12px);
-    border: 1px solid rgba(255, 255, 255, 0.2);
+    border: 1px solid rgba(255, 255, 255, 0.15);
     border-radius: 12px;
     box-shadow:
       0 8px 32px rgba(0, 0, 0, 0.3),
@@ -112,6 +112,7 @@
   }
   .pdf-pages.dark-mode .pdf-page canvas {
     filter: invert(1) hue-rotate(180deg);
+    opacity: 0.88;
   }
   .pdf-pages.dark-mode .pdf-page .textLayer ::selection {
     background: rgba(100, 150, 255, 0.5);
@@ -135,7 +136,9 @@
   }
   .pdf-pages {
     box-shadow: 0 2px 10px rgba(0,0,0,0.3);
-    background: rgba(255, 255, 255, 0.92);
+    background: rgba(255, 255, 255, 0.75);
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
     border-radius: 6px;
     overflow: hidden;
   }
@@ -147,6 +150,7 @@
     background: transparent;
     position: relative;
     z-index: 1;
+    opacity: 0.92;
   }
   /* Text layer for selectable/searchable text */
   .pdf-page .textLayer {

--- a/sw.js
+++ b/sw.js
@@ -1,6 +1,6 @@
 // Service Worker for SWU Calculator PWA
 // Version must be updated when deploying new code to bust cache
-const CACHE_VERSION = 'v117';
+const CACHE_VERSION = 'v118';
 const CACHE_NAME = `swu-calculator-${CACHE_VERSION}`;
 
 // Files to cache for offline use


### PR DESCRIPTION
## Summary
Enhanced the PDF viewer's visual appearance by refining the glassmorphism effect and adjusting opacity levels for better readability in both light and dark modes.

## Key Changes
- **Dark mode styling**: Reduced background opacity from 0.1 to 0.06 and border opacity from 0.2 to 0.15 for a more subtle glassmorphic effect
- **Dark mode canvas rendering**: Added 0.88 opacity to inverted PDF canvas to improve visibility and reduce harshness of the invert filter
- **Light mode styling**: 
  - Reduced background opacity from 0.92 to 0.75
  - Added backdrop blur filter (12px) with webkit prefix for consistent glassmorphism
  - Added 0.92 opacity to PDF page container for refined appearance
- **Cache invalidation**: Bumped service worker cache version from v117 to v118 to ensure users receive the updated styles

## Implementation Details
The changes maintain the glassmorphic design pattern while improving visual hierarchy and readability. The opacity adjustments work in conjunction with the backdrop blur to create a more polished, modern appearance without compromising content visibility. Both light and dark modes now use consistent blur effects for a unified design language.

https://claude.ai/code/session_01XPgQfLJzbe3R2LY357UTDz