### PR TITLE
Adjust PDF opacity and bump service worker cache version

### DIFF
--- a/pages/resume.html
+++ b/pages/resume.html
@@ -150,7 +150,7 @@
     background: transparent;
     position: relative;
     z-index: 1;
-    opacity: 0.92;
+    opacity: 0.85;
   }
   /* Text layer for selectable/searchable text */
   .pdf-page .textLayer {

--- a/sw.js
+++ b/sw.js
@@ -1,6 +1,6 @@
 // Service Worker for SWU Calculator PWA
 // Version must be updated when deploying new code to bust cache
-const CACHE_VERSION = 'v118';
+const CACHE_VERSION = 'v119';
 const CACHE_NAME = `swu-calculator-${CACHE_VERSION}`;
 
 // Files to cache for offline use


### PR DESCRIPTION
## Summary
This PR makes a minor visual adjustment to the PDF viewer and updates the service worker cache version to ensure users receive the latest assets.

## Key Changes
- **PDF Viewer**: Reduced the opacity of the PDF canvas layer from 0.92 to 0.85 for improved visual appearance
- **Service Worker**: Incremented cache version from v118 to v119 to invalidate the browser cache and force users to download updated assets

## Implementation Details
The opacity change affects the `.pdf-page` canvas element, making it slightly more transparent while maintaining readability. The service worker cache version bump is a standard deployment practice that ensures all cached files are refreshed when new code is deployed.

https://claude.ai/code/session_01Q3qUgqoPUFf1y17a8S3gqe