### PR TITLE
Adjust PDF viewer transparency and update cache version

### DIFF
--- a/pages/resume.html
+++ b/pages/resume.html
@@ -136,7 +136,7 @@
   }
   .pdf-pages {
     box-shadow: 0 2px 10px rgba(0,0,0,0.3);
-    background: rgba(255, 255, 255, 0.75);
+    background: rgba(255, 255, 255, 0.15);
     backdrop-filter: blur(12px);
     -webkit-backdrop-filter: blur(12px);
     border-radius: 6px;
@@ -150,7 +150,7 @@
     background: transparent;
     position: relative;
     z-index: 1;
-    opacity: 0.85;
+    opacity: 0.75;
   }
   /* Text layer for selectable/searchable text */
   .pdf-page .textLayer {

--- a/sw.js
+++ b/sw.js
@@ -1,6 +1,6 @@
 // Service Worker for SWU Calculator PWA
 // Version must be updated when deploying new code to bust cache
-const CACHE_VERSION = 'v119';
+const CACHE_VERSION = 'v120';
 const CACHE_NAME = `swu-calculator-${CACHE_VERSION}`;
 
 // Files to cache for offline use


### PR DESCRIPTION
## Summary
This PR refines the visual appearance of the PDF viewer component by adjusting transparency levels for better readability and updates the service worker cache version to invalidate cached assets.

## Key Changes
- **PDF Pages Background**: Reduced background opacity from 0.75 to 0.15 for a more transparent glassmorphism effect
- **PDF Page Opacity**: Decreased opacity from 0.85 to 0.75 for subtler rendering
- **Cache Version**: Bumped service worker cache version from v119 to v120 to force cache invalidation on deployment

## Implementation Details
The transparency adjustments to the `.pdf-pages` and `.pdf-page` CSS classes create a lighter, more transparent appearance while maintaining the backdrop blur effect. The service worker cache version increment ensures users receive the latest assets on their next visit.

https://claude.ai/code/session_01SGco7sjjpQgy9fex77nxA1