### PR TITLE
Add PDF.js viewer stylesheet and fix text layer scaling

### DIFF
--- a/pages/resume.html
+++ b/pages/resume.html
@@ -342,6 +342,7 @@
   <div class="pdf-loading" id="pdf-loading">Loading resume...</div>
   <div class="pdf-pages" id="pdf-pages"></div>
 </div>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.11.174/pdf_viewer.min.css">
 <script>
 (function() {
   var script = document.createElement('script');
@@ -392,6 +393,8 @@
           // Create text layer div
           var textLayerDiv = document.createElement('div');
           textLayerDiv.className = 'textLayer';
+          // PDF.js 3.x requires --scale-factor for proper text span positioning
+          textLayerDiv.style.setProperty('--scale-factor', baseScale);
           pageDiv.appendChild(textLayerDiv);
 
           container.appendChild(pageDiv);

--- a/sw.js
+++ b/sw.js
@@ -1,6 +1,6 @@
 // Service Worker for SWU Calculator PWA
 // Version must be updated when deploying new code to bust cache
-const CACHE_VERSION = 'v121';
+const CACHE_VERSION = 'v122';
 const CACHE_NAME = `swu-calculator-${CACHE_VERSION}`;
 
 // Files to cache for offline use


### PR DESCRIPTION
## Summary
This PR adds proper styling support for PDF.js 3.x and fixes text layer positioning by including the PDF viewer stylesheet and setting the required scale factor CSS variable.

## Key Changes
- Added PDF.js 3.11.174 viewer stylesheet link to resume.html for proper PDF rendering styles
- Set the `--scale-factor` CSS custom property on text layer divs to ensure correct text span positioning in PDF.js 3.x
- Updated service worker cache version to v122 to invalidate cached assets

## Implementation Details
The PDF.js 3.x library requires the `--scale-factor` CSS variable to be set on text layer elements for proper text positioning and selection. The stylesheet inclusion ensures all necessary PDF viewer styles are applied, while the dynamic scale factor assignment maintains compatibility with the rendering scale used during PDF page rendering.

https://claude.ai/code/session_01CFpLv9kMfVcQBCfUGkC5zd