### PR TITLE
Replace overflow: hidden with overflow: clip in resume PDF viewer

### DIFF
--- a/pages/resume.html
+++ b/pages/resume.html
@@ -140,7 +140,7 @@
     backdrop-filter: blur(12px);
     -webkit-backdrop-filter: blur(12px);
     border-radius: 6px;
-    overflow: hidden;
+    overflow: clip;
   }
   .pdf-page {
     position: relative;
@@ -159,7 +159,7 @@
     top: 0;
     right: 0;
     bottom: 0;
-    overflow: hidden;
+    overflow: clip;
     opacity: 1;
     line-height: 1.0;
     pointer-events: auto;

--- a/sw.js
+++ b/sw.js
@@ -1,6 +1,6 @@
 // Service Worker for SWU Calculator PWA
 // Version must be updated when deploying new code to bust cache
-const CACHE_VERSION = 'v121';
+const CACHE_VERSION = 'v122';
 const CACHE_NAME = `swu-calculator-${CACHE_VERSION}`;
 
 // Files to cache for offline use


### PR DESCRIPTION
## Summary
Updated CSS overflow properties in the resume PDF viewer and bumped the service worker cache version to ensure the changes are deployed to all clients.

## Key Changes
- Changed `overflow: hidden` to `overflow: clip` in two CSS rules for the PDF viewer container and text layer (lines 143 and 162 in pages/resume.html)
- Incremented service worker cache version from `v121` to `v122` to bust the cache and force clients to fetch updated assets

## Implementation Details
The `overflow: clip` property is a more modern CSS approach that clips content without creating a new block formatting context, unlike `overflow: hidden`. This change improves CSS efficiency while maintaining the same visual behavior of clipping overflowing content in the PDF viewer.

The cache version bump ensures that users will receive the updated CSS changes rather than serving stale cached assets.

https://claude.ai/code/session_01PqQQzgvYVrTWbPM49KoPtS