### PR TITLE
Fix touch/trackpad scrolling in PDF text layer

### DIFF
--- a/pages/resume.html
+++ b/pages/resume.html
@@ -175,6 +175,8 @@
     -ms-text-size-adjust: none;
     /* Accessibility: preserve intended colors in forced color modes */
     forced-color-adjust: none;
+    /* Allow trackpad/touch scrolling to pass through the text layer */
+    touch-action: auto;
   }
   .pdf-page .textLayer > span {
     color: transparent;
@@ -188,8 +190,8 @@
     -ms-user-select: text;
     /* Ensure spans can receive pointer events for selection */
     pointer-events: auto;
-    /* Allow vertical scrolling through text layer on touch devices */
-    touch-action: pan-y;
+    /* Allow all default touch/trackpad gestures (scroll, pinch, etc.) */
+    touch-action: auto;
   }
   .pdf-page .textLayer > span:not(:empty)::selection,
   .pdf-page .textLayer > span:not(:empty) *::selection {

--- a/sw.js
+++ b/sw.js
@@ -1,6 +1,6 @@
 // Service Worker for SWU Calculator PWA
 // Version must be updated when deploying new code to bust cache
-const CACHE_VERSION = 'v122';
+const CACHE_VERSION = 'v123';
 const CACHE_NAME = `swu-calculator-${CACHE_VERSION}`;
 
 // Files to cache for offline use


### PR DESCRIPTION
## Summary
Updated touch-action CSS properties in the PDF text layer to properly allow trackpad and touch scrolling gestures to pass through to the underlying content.

## Key Changes
- Changed `touch-action: pan-y` to `touch-action: auto` on `.pdf-page .textLayer > span` to allow all default touch and trackpad gestures (scrolling, pinching, etc.)
- Added `touch-action: auto` to `.pdf-page .textLayer` to ensure the parent container also permits default touch behaviors
- Updated service worker cache version from v122 to v123 to invalidate cached assets

## Implementation Details
The previous `pan-y` value restricted touch actions to vertical panning only, which could interfere with trackpad scrolling and other gestures. Changing to `touch-action: auto` restores browser default behavior while maintaining the transparent text layer's ability to receive pointer events for text selection.

https://claude.ai/code/session_013gae84MJnbo5vWvM6h9PrY