### PR TITLE
Adjust PDF dark mode opacity and bump cache version

### DIFF
--- a/pages/resume.html
+++ b/pages/resume.html
@@ -112,7 +112,7 @@
   }
   .pdf-pages.dark-mode .pdf-page canvas {
     filter: invert(1) hue-rotate(180deg);
-    opacity: 0.88;
+    opacity: 0.6;
   }
   .pdf-pages.dark-mode .pdf-page .textLayer ::selection {
     background: rgba(100, 150, 255, 0.5);

--- a/sw.js
+++ b/sw.js
@@ -1,6 +1,6 @@
 // Service Worker for SWU Calculator PWA
 // Version must be updated when deploying new code to bust cache
-const CACHE_VERSION = 'v129';
+const CACHE_VERSION = 'v130';
 const CACHE_NAME = `swu-calculator-${CACHE_VERSION}`;
 
 // Files to cache for offline use


### PR DESCRIPTION
## Summary
This PR makes a minor adjustment to the PDF viewer's dark mode styling and updates the service worker cache version to ensure users receive the latest assets.

## Key Changes
- **PDF Dark Mode Opacity**: Reduced the opacity filter for PDF pages in dark mode from `0.88` to `0.6` for improved visibility and contrast
- **Cache Version Bump**: Updated service worker cache version from `v129` to `v130` to invalidate the browser cache and force users to fetch the latest version of the application

## Implementation Details
The opacity change affects the `filter: invert(1) hue-rotate(180deg)` effect applied to PDF canvas elements in dark mode, making the inverted content appear darker and potentially more readable. The cache version increment ensures this styling change is delivered to all users by busting their cached assets.

https://claude.ai/code/session_01JDxK37o9QXSxVtHbskQD3f