### PR TITLE
Fix PDF resume scrolling with trackpad gestures

### DIFF
--- a/pages/resume.html
+++ b/pages/resume.html
@@ -358,6 +358,17 @@
     var container = document.getElementById('pdf-pages');
     var loading = document.getElementById('pdf-loading');
 
+    // Forward trackpad/mouse wheel events to window scroll. The PDF.js text
+    // layer uses pointer-events: auto so text is selectable, which also
+    // captures wheel events over the résumé. Explicitly translating wheel
+    // deltas into window scroll keeps two-finger trackpad gestures working
+    // without breaking text selection or ctrl+wheel zoom.
+    container.addEventListener('wheel', function(e) {
+      if (e.ctrlKey) return;
+      window.scrollBy({ left: e.deltaX, top: e.deltaY });
+      e.preventDefault();
+    }, { passive: false });
+
     pdfjsLib.getDocument(url).promise.then(function(pdf) {
       loading.style.display = 'none';
 

--- a/sw.js
+++ b/sw.js
@@ -1,6 +1,6 @@
 // Service Worker for SWU Calculator PWA
 // Version must be updated when deploying new code to bust cache
-const CACHE_VERSION = 'v130';
+const CACHE_VERSION = 'v131';
 const CACHE_NAME = `swu-calculator-${CACHE_VERSION}`;
 
 // Files to cache for offline use


### PR DESCRIPTION
## Summary
Fixed an issue where two-finger trackpad scroll gestures were not working on the embedded PDF resume viewer. The PDF.js text layer's `pointer-events: auto` was capturing wheel events, preventing natural scrolling behavior.

## Changes
- Added a wheel event listener to the PDF container that forwards scroll deltas to the window when not using ctrl+wheel (zoom)
- The listener explicitly prevents default wheel behavior to avoid conflicts with text selection
- Updated service worker cache version to v131 to invalidate cached assets

## Implementation Details
The solution intercepts wheel events on the PDF container and translates them into `window.scrollBy()` calls. This approach:
- Preserves two-finger trackpad scrolling functionality
- Maintains text selection capability (pointer-events still active)
- Respects ctrl+wheel zoom by returning early when `ctrlKey` is detected
- Uses `{ passive: false }` to allow `preventDefault()` on wheel events

https://claude.ai/code/session_01Ey1B69F8dJZe7dJqTrNJQX