### PR TITLE
Improve PDF rendering with transparent backgrounds and wave effect

### DIFF
--- a/pages/resume.html
+++ b/pages/resume.html
@@ -112,7 +112,6 @@
   }
   .pdf-pages.dark-mode .pdf-page canvas {
     filter: invert(1) hue-rotate(180deg);
-    opacity: 0.6;
   }
   .pdf-pages.dark-mode .pdf-page .textLayer ::selection {
     background: rgba(100, 150, 255, 0.5);
@@ -150,7 +149,6 @@
     background: transparent;
     position: relative;
     z-index: 1;
-    opacity: 0.75;
   }
   /* Text layer for selectable/searchable text */
   .pdf-page .textLayer {
@@ -401,10 +399,13 @@
 
           container.appendChild(pageDiv);
 
-          // Render canvas
+          // Render canvas with transparent background so only PDF content
+          // (text, images) is painted — the white page fill is skipped so
+          // the wave background shows through.
           var renderTask = page.render({
             canvasContext: context,
-            viewport: viewport
+            viewport: viewport,
+            background: 'rgba(0,0,0,0)'
           });
 
           // Render text layer for selectable/searchable text

--- a/sw.js
+++ b/sw.js
@@ -1,6 +1,6 @@
 // Service Worker for SWU Calculator PWA
 // Version must be updated when deploying new code to bust cache
-const CACHE_VERSION = 'v130';
+const CACHE_VERSION = 'v131';
 const CACHE_NAME = `swu-calculator-${CACHE_VERSION}`;
 
 // Files to cache for offline use


### PR DESCRIPTION
## Summary
This PR improves the visual presentation of PDF rendering by removing opacity constraints and enabling transparent backgrounds so the wave background effect shows through the PDF pages.

## Key Changes
- Removed `opacity: 0.6` filter from dark mode PDF canvas rendering to restore full visibility
- Removed `opacity: 0.75` from the PDF page container to eliminate unnecessary transparency
- Added `background: 'rgba(0,0,0,0)'` to the PDF render task configuration to render PDFs with transparent backgrounds instead of white fills
- Updated service worker cache version from v130 to v131 to invalidate cached assets

## Implementation Details
The PDF rendering now uses a transparent background, which allows the wave background pattern to be visible behind the PDF content. This creates a more visually integrated design where the PDF pages appear to float over the animated wave background rather than being opaque white rectangles. The removal of the opacity properties ensures that both the canvas and container maintain full opacity while the transparency is controlled at the render level.

https://claude.ai/code/session_01XrWjtd1Lur2vEZH4gLSf56