### PR TITLE
Unify vertical sizing: make #site-shell own height and use --nav-height in .content

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -64,6 +64,8 @@ body {
 
 #site-shell {
   position: relative;
+  display: flex;
+  flex-direction: column;
   min-height: 100vh;
   min-height: 100svh;
   transition: filter 0.22s ease;
@@ -130,8 +132,11 @@ select {
 .content {
   position: relative;
   z-index: 10;
-  margin-top: 56px;
-  padding: 0 1rem;
+  flex: 1 1 auto;
+  min-height: calc(100vh - var(--nav-height));
+  min-height: calc(100svh - var(--nav-height));
+  box-sizing: border-box;
+  padding: var(--nav-height) 1rem 0;
   font-family: 'Inter', sans-serif;
   color: white;
   opacity: 1;

--- a/pages/home.html
+++ b/pages/home.html
@@ -19,8 +19,8 @@
     margin: 0;
   }
   .home-container {
-    min-height: calc(100vh - 56px - 2rem);
-    min-height: calc(100svh - 56px - 2rem); /* Mobile-friendly viewport height */
+    flex: 1 1 auto;
+    min-height: 0;
     display: flex;
     justify-content: center;
     align-items: center;

--- a/sw.js
+++ b/sw.js
@@ -1,6 +1,6 @@
 // Service Worker for SWU Calculator PWA
 // Version must be updated when deploying new code to bust cache
-const CACHE_VERSION = 'v132';
+const CACHE_VERSION = 'v133';
 const CACHE_NAME = `swu-calculator-${CACHE_VERSION}`;
 
 // Files to cache for offline use


### PR DESCRIPTION
### Motivation
- Ensure a single layout component controls vertical sizing so pages don’t compensate in multiple places and cause double-subtraction issues.
- Replace hardcoded `56px` arithmetic with the single source of truth `--nav-height` to avoid drift if nav sizing changes.
- Make the home page rely on the shared layout instead of redoing viewport-minus-nav math locally.

### Description
- Converted `#site-shell` to a column flex container (`display: flex; flex-direction: column;`) so the shell owns page-height flow in `css/main.css`.
- Updated `.content` to `flex: 1 1 auto`, added `min-height: calc(100svh - var(--nav-height))` and top padding `padding: var(--nav-height) 1rem 0` to centralize viewport sizing in `css/main.css`.
- Removed duplicate viewport-minus-nav math from `pages/home.html` by making `.home-container` a flexible child (`flex: 1 1 auto; min-height: 0`) that relies on `.content` for vertical sizing.
- Replaced local hardcoded offsets by using the existing `--nav-height` variable and bumped the service worker `CACHE_VERSION` to `v133` in `sw.js` to reflect the HTML/CSS update.

### Testing
- Ran `npm test` (Vitest) which completed successfully with all tests passing (`nuclear/nuclear-math.test.js`: 56 tests passed).
- No automated visual viewport screenshots were available in this environment, so visual validation at 90%, 100%, 110%, and mobile emulation was not performed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7f6e9bc28832d997e040f5a4754b2)