### PR TITLE
Center home link buttons vertically

### DIFF
--- a/pages/home.html
+++ b/pages/home.html
@@ -20,7 +20,9 @@
   }
   .home-container {
     flex: 1 1 auto;
-    min-height: 0;
+    min-height: calc(100svh - var(--nav-height));
+    min-height: calc(100vh - var(--nav-height));
+    box-sizing: border-box;
     display: flex;
     justify-content: center;
     align-items: center;

--- a/sw.js
+++ b/sw.js
@@ -1,6 +1,6 @@
 // Service Worker for SWU Calculator PWA
 // Version must be updated when deploying new code to bust cache
-const CACHE_VERSION = 'v133';
+const CACHE_VERSION = 'v134';
 const CACHE_NAME = `swu-calculator-${CACHE_VERSION}`;
 
 // Files to cache for offline use


### PR DESCRIPTION
### Motivation
- The home page link buttons appeared near the top of the viewport on some devices; they should be centered vertically within the visible area beneath the fixed nav.

### Description
- Adjusted `.home-container` in `pages/home.html` to use `min-height: calc(100svh - var(--nav-height))` with a `100vh` fallback and `box-sizing: border-box` to ensure the link list is vertically centered, and incremented the service worker `CACHE_VERSION` in `sw.js` to `v134` so clients pick up the style update.

### Testing
- Ran `npm test` (Vitest) and all tests passed (`nuclear/nuclear-math.test.js`: 56/56).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7f833c814832d87407323239934a3)