### PR TITLE
Improve PDF rendering in dark mode using blend modes

### DIFF
--- a/pages/resume.html
+++ b/pages/resume.html
@@ -112,6 +112,9 @@
   }
   .pdf-pages.dark-mode .pdf-page canvas {
     filter: invert(1) hue-rotate(180deg);
+    /* After inversion the page fill is black and text is light, so use
+       `screen` to drop the black while keeping light text opaque. */
+    mix-blend-mode: screen;
   }
   .pdf-pages.dark-mode .pdf-page .textLayer ::selection {
     background: rgba(100, 150, 255, 0.5);
@@ -149,6 +152,10 @@
     background: transparent;
     position: relative;
     z-index: 1;
+    /* White page fill blends out against the backdrop while dark text
+       stays fully opaque — avoids relying on PDF.js's `background`
+       render option, which can leave text semi-transparent. */
+    mix-blend-mode: multiply;
   }
   /* Text layer for selectable/searchable text */
   .pdf-page .textLayer {
@@ -399,13 +406,9 @@
 
           container.appendChild(pageDiv);
 
-          // Render canvas with transparent background so only PDF content
-          // (text, images) is painted — the white page fill is skipped so
-          // the wave background shows through.
           var renderTask = page.render({
             canvasContext: context,
-            viewport: viewport,
-            background: 'rgba(0,0,0,0)'
+            viewport: viewport
           });
 
           // Render text layer for selectable/searchable text

--- a/sw.js
+++ b/sw.js
@@ -1,6 +1,6 @@
 // Service Worker for SWU Calculator PWA
 // Version must be updated when deploying new code to bust cache
-const CACHE_VERSION = 'v134';
+const CACHE_VERSION = 'v135';
 const CACHE_NAME = `swu-calculator-${CACHE_VERSION}`;
 
 // Files to cache for offline use


### PR DESCRIPTION
## Summary
Refactored PDF rendering to use CSS blend modes instead of relying on PDF.js's transparent background option. This provides better visual results in both light and dark modes while simplifying the rendering configuration.

## Key Changes
- **Dark mode PDF rendering**: Added `mix-blend-mode: screen` to the canvas filter to properly handle the inverted colors, dropping the black page fill while preserving light text opacity
- **Light mode PDF rendering**: Added `mix-blend-mode: multiply` to the text layer to blend out the white page fill against the backdrop while keeping dark text fully opaque
- **Removed transparent background option**: Eliminated the `background: 'rgba(0,0,0,0)'` parameter from the PDF.js render call, as the blend modes now handle the page fill blending more elegantly
- **Updated service worker cache version**: Bumped from v134 to v135 to invalidate cached assets

## Implementation Details
The previous approach relied on PDF.js's `background` option to skip rendering the white page fill, but this could leave text semi-transparent. The new approach uses CSS blend modes to achieve the desired effect:
- In dark mode, the `screen` blend mode drops black while preserving light colors
- In light mode, the `multiply` blend mode blends out white while preserving dark colors

This eliminates the need for special rendering configuration and provides more consistent results across different PDF content.

https://claude.ai/code/session_01Kq2a7ZHvMK28c2dxzkQEiy