### PR TITLE
Add box-sizing to tools container and bump service worker cache version

### DIFF
--- a/pages/tools.html
+++ b/pages/tools.html
@@ -9,6 +9,7 @@
     --glass-frost: 0.1;
     --glass-saturation: 1.2;
     --filter-id: url(#glass-filter);
+    box-sizing: border-box;
     min-height: calc(100vh - 56px - 2rem);
     min-height: calc(100svh - 56px - 2rem);
     display: flex;

--- a/sw.js
+++ b/sw.js
@@ -1,6 +1,6 @@
 // Service Worker for SWU Calculator PWA
 // Version must be updated when deploying new code to bust cache
-const CACHE_VERSION = 'v136';
+const CACHE_VERSION = 'v137';
 const CACHE_NAME = `swu-calculator-${CACHE_VERSION}`;
 
 // Files to cache for offline use


### PR DESCRIPTION
### Motivation

- Ensure the tools page layout calculates widths consistently across browsers by including `box-sizing: border-box` on the `.tools-container`.
- Force clients to fetch updated assets by incrementing the service worker cache version so the new site resources are served after deploy.

### Description

- Added `box-sizing: border-box;` to the `.tools-container` CSS in `pages/tools.html` to make padding and width calculations more predictable.
- Bumped the service worker cache version from `v136` to `v137` in `sw.js` to invalidate previous caches and trigger asset refresh on clients.

### Testing

- Ran `npm run build` locally and the build completed successfully.
- Ran `npm run lint` locally and there were no linting errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8597eb8a0832db2db6fef823a1a77)