### PR TITLE
Add panoramic.bennyhartnett.com viewer (Pannellum) with loop toggle

### DIFF
--- a/js/meta-manager.js
+++ b/js/meta-manager.js
@@ -75,6 +75,12 @@ const META_MAP = {
     ogImage: BASE_OG_IMAGE,
     ogImageAlt: 'Clipboard - Peer-to-Peer File Sharing'
   },
+  'pages/panoramic.html': {
+    title: 'Panoramic Viewer - Benny Hartnett',
+    desc: 'Client-side 360° panoramic photo viewer with optional looped auto-rotation controls.',
+    ogImage: BASE_OG_IMAGE,
+    ogImageAlt: 'Panoramic Viewer - Street View style photo exploration'
+  },
   'pages/tools.html': {
     title: 'Tools - Benny Hartnett',
     desc: 'Apps and utilities including video conferencing, clipboard sharing, and calculators.',

--- a/pages/panoramic.html
+++ b/pages/panoramic.html
@@ -1,0 +1,229 @@
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/pannellum@2.5.6/build/pannellum.css" />
+
+<style>
+  .panoramic-page {
+    min-height: calc(100vh - 56px - 2rem);
+    min-height: calc(100svh - 56px - 2rem);
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    width: min(100%, 1100px);
+    margin: 0 auto;
+    padding: 1.25rem 1rem 1rem;
+    color: #ffffff;
+    font-family: 'Inter', sans-serif;
+  }
+
+  .panoramic-header h1 {
+    margin: 0;
+    font-size: clamp(1.4rem, 2.5vw, 2rem);
+  }
+
+  .panoramic-header p {
+    margin: 0.4rem 0 0;
+    color: rgba(255, 255, 255, 0.75);
+  }
+
+  .panoramic-controls {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    align-items: center;
+    padding: 0.85rem;
+    border-radius: 12px;
+    background: rgba(255, 255, 255, 0.08);
+    backdrop-filter: blur(10px);
+    -webkit-backdrop-filter: blur(10px);
+  }
+
+  .panoramic-url {
+    flex: 1 1 420px;
+    min-width: 240px;
+    height: 2.5rem;
+    border-radius: 8px;
+    border: 1px solid rgba(255, 255, 255, 0.25);
+    background: rgba(0, 0, 0, 0.35);
+    color: #ffffff;
+    padding: 0 0.75rem;
+    font-size: 0.92rem;
+  }
+
+  .panoramic-url::placeholder {
+    color: rgba(255, 255, 255, 0.5);
+  }
+
+  .panoramic-btn {
+    border: 1px solid rgba(255, 255, 255, 0.3);
+    border-radius: 8px;
+    background: rgba(255, 255, 255, 0.12);
+    color: #ffffff;
+    font-size: 0.9rem;
+    padding: 0.58rem 0.9rem;
+    cursor: pointer;
+    transition: background 0.2s ease, transform 0.2s ease;
+  }
+
+  .panoramic-btn:hover {
+    background: rgba(255, 255, 255, 0.2);
+    transform: translateY(-1px);
+  }
+
+  .panoramic-toggle {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.45rem;
+    font-size: 0.9rem;
+    color: rgba(255, 255, 255, 0.95);
+    user-select: none;
+  }
+
+  .panoramic-toggle input {
+    width: 1rem;
+    height: 1rem;
+    accent-color: #6fb1ff;
+  }
+
+  .panoramic-status {
+    margin: 0;
+    font-size: 0.85rem;
+    color: rgba(255, 255, 255, 0.75);
+    min-height: 1.25rem;
+  }
+
+  .panoramic-viewer {
+    width: 100%;
+    height: min(68vh, 680px);
+    min-height: 400px;
+    border-radius: 12px;
+    overflow: hidden;
+    border: 1px solid rgba(255, 255, 255, 0.15);
+    box-shadow: 0 12px 40px rgba(0, 0, 0, 0.35);
+  }
+
+  @media (max-width: 720px) {
+    .panoramic-controls {
+      padding: 0.75rem;
+    }
+
+    .panoramic-viewer {
+      min-height: 320px;
+      height: 54vh;
+    }
+  }
+</style>
+
+<div class="panoramic-page">
+  <header class="panoramic-header">
+    <h1>Panoramic Viewer</h1>
+    <p>Look around a 360° panoramic photo like Street View. Paste any equirectangular image URL to load your own scene.</p>
+  </header>
+
+  <div class="panoramic-controls">
+    <input
+      id="panoramic-url"
+      class="panoramic-url"
+      type="url"
+      value="https://pannellum.org/images/alma.jpg"
+      placeholder="https://example.com/panorama.jpg"
+      aria-label="Panoramic image URL"
+    />
+    <button id="panoramic-load" class="panoramic-btn" type="button">Load photo</button>
+    <button id="panoramic-reset" class="panoramic-btn" type="button">Reset view</button>
+    <label class="panoramic-toggle" for="panoramic-loop">
+      <input id="panoramic-loop" type="checkbox" checked />
+      360 loop
+    </label>
+  </div>
+
+  <p id="panoramic-status" class="panoramic-status">Ready.</p>
+
+  <div id="panoramic-viewer" class="panoramic-viewer" aria-label="Panoramic viewer"></div>
+</div>
+
+<script src="https://cdn.jsdelivr.net/npm/pannellum@2.5.6/build/pannellum.js"></script>
+<script>
+  (() => {
+    const scope = document.currentScript.closest('.panoramic-page');
+    if (!scope || !window.pannellum) {
+      return;
+    }
+
+    const viewerNode = scope.querySelector('#panoramic-viewer');
+    const urlInput = scope.querySelector('#panoramic-url');
+    const loadButton = scope.querySelector('#panoramic-load');
+    const resetButton = scope.querySelector('#panoramic-reset');
+    const loopToggle = scope.querySelector('#panoramic-loop');
+    const statusNode = scope.querySelector('#panoramic-status');
+
+    let viewer;
+
+    function setStatus(message, isError = false) {
+      statusNode.textContent = message;
+      statusNode.style.color = isError ? 'rgba(255, 110, 110, 0.95)' : 'rgba(255, 255, 255, 0.75)';
+    }
+
+    function applyLoopSetting() {
+      if (!viewer) return;
+      if (loopToggle.checked) {
+        viewer.startAutoRotate(-2);
+      } else {
+        viewer.stopAutoRotate();
+      }
+    }
+
+    function createViewer(url) {
+      if (!url) {
+        setStatus('Enter a panoramic image URL first.', true);
+        return;
+      }
+
+      viewerNode.innerHTML = '';
+      viewer = pannellum.viewer(viewerNode, {
+        type: 'equirectangular',
+        panorama: url,
+        autoLoad: true,
+        showZoomCtrl: true,
+        showFullscreenCtrl: true,
+        mouseZoom: true,
+        compass: false
+      });
+
+      viewer.on('load', () => {
+        setStatus('Panorama loaded. Drag to look around.');
+        applyLoopSetting();
+      });
+
+      viewer.on('error', (error) => {
+        const message = error && error.message ? error.message : 'Unable to load that image URL.';
+        setStatus(message, true);
+      });
+    }
+
+    loadButton.addEventListener('click', () => {
+      createViewer(urlInput.value.trim());
+    });
+
+    urlInput.addEventListener('keydown', (event) => {
+      if (event.key === 'Enter') {
+        event.preventDefault();
+        createViewer(urlInput.value.trim());
+      }
+    });
+
+    resetButton.addEventListener('click', () => {
+      if (!viewer) return;
+      viewer.setPitch(0);
+      viewer.setYaw(0);
+      viewer.setHfov(100);
+      applyLoopSetting();
+      setStatus('View reset.');
+    });
+
+    loopToggle.addEventListener('change', () => {
+      applyLoopSetting();
+      setStatus(loopToggle.checked ? '360 loop enabled.' : '360 loop disabled.');
+    });
+
+    createViewer(urlInput.value.trim());
+  })();
+</script>

--- a/pages/tools.html
+++ b/pages/tools.html
@@ -239,6 +239,17 @@
       <span class="tool-tag">AI</span>
     </a>
 
+
+    <a href="/panoramic" class="tool-card">
+      <div class="tool-card__code" aria-hidden="true"></div>
+      <div class="tool-header">
+        <span class="tool-icon"><svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="m2.25 12 8.954-8.955a1.125 1.125 0 0 1 1.59 0L21.75 12m-2.25 0v7.125A1.125 1.125 0 0 1 18.375 20.25H5.625A1.125 1.125 0 0 1 4.5 19.125V12m5.25 8.25v-5.625a1.125 1.125 0 0 1 1.125-1.125h2.25a1.125 1.125 0 0 1 1.125 1.125v5.625" /></svg></span>
+        <h2>Panoramic Viewer</h2>
+      </div>
+      <p>Street View-style client-side 360° photo viewer with a quick toggle for looped rotation.</p>
+      <span class="tool-tag">360°</span>
+    </a>
+
     <div class="tool-card coming-soon">
       <div class="tool-header">
         <span class="tool-icon"><svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M11.42 15.17 17.25 21A2.652 2.652 0 0 0 21 17.25l-5.877-5.877M11.42 15.17l2.496-3.03c.317-.384.74-.626 1.208-.766M11.42 15.17l-4.655 5.653a2.548 2.548 0 1 1-3.586-3.586l6.837-5.63m5.108-.233c.55-.164 1.163-.188 1.743-.14a4.5 4.5 0 0 0 4.486-6.336l-3.276 3.277a3.004 3.004 0 0 1-2.25-2.25l3.276-3.276a4.5 4.5 0 0 0-6.336 4.486c.091 1.076-.071 2.264-.904 2.95l-.102.085m-1.745 1.437L5.909 7.5H4.5L2.25 3.75l1.5-1.5L7.5 4.5v1.409l4.26 4.26m-1.745 1.437 1.745-1.437m6.615 8.206L15.75 15.75M4.867 19.125h.008v.008h-.008v-.008Z" /></svg></span>

--- a/sw.js
+++ b/sw.js
@@ -1,6 +1,6 @@
 // Service Worker for SWU Calculator PWA
 // Version must be updated when deploying new code to bust cache
-const CACHE_VERSION = 'v136';
+const CACHE_VERSION = 'v137';
 const CACHE_NAME = `swu-calculator-${CACHE_VERSION}`;
 
 // Files to cache for offline use
@@ -19,6 +19,7 @@ const STATIC_ASSETS = [
   '/pages/chat.html',
   '/pages/meet.html',
   '/pages/tools.html',
+  '/pages/panoramic.html',
   '/pages/fx.html',
   '/pages/clipboard.html',
   '/pages/search.html',


### PR DESCRIPTION
### Motivation
- Provide a Street View-style, client-side panoramic photo viewer reachable at `panoramic.bennyhartnett.com` using the existing SPA subdomain convention.
- Allow users to load arbitrary equirectangular images and optionally enable a continuous 360° auto-rotation for hands-free viewing.

### Description
- Added a new SPA fragment `pages/panoramic.html` that embeds Pannellum and implements URL input, load/reset controls, status/error messaging, and a `360 loop` checkbox to toggle auto-rotation (default: checked).
- Registered the new page in `js/meta-manager.js` so the SPA updates title/description/OG tags for `pages/panoramic.html`.
- Added a discoverability entry in `pages/tools.html` (tools grid card linking to `/panoramic`).
- Updated the service worker `sw.js` by incrementing `CACHE_VERSION` to `v137` and adding `/pages/panoramic.html` to `STATIC_ASSETS` for offline caching.

### Testing
- Ran the test suite with `npm test` (Vitest), and all tests passed: `56/56` passing.
- Verified the new page and tooling changes were added; no automated UI tests were added for the viewer (manual browser validation expected).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e85a2c1f50832da82c9c92ed57b1f6)