### PR TITLE
Add CI quality checks, service-worker guardrails, PR smoke checks, and router unit tests

### DIFF
--- a/.github/workflows/quality-checks.yml
+++ b/.github/workflows/quality-checks.yml
@@ -1,0 +1,63 @@
+name: Quality Checks
+
+on:
+  pull_request:
+    branches: ["main"]
+  push:
+    branches: ["main"]
+
+jobs:
+  tests:
+    name: Unit Tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run unit tests
+        run: npm test
+
+  sw-guardrails:
+    name: Service Worker Guardrails
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Run service worker guardrail checks
+        env:
+          BASE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
+          HEAD_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+        run: node scripts/ci/check-sw-guardrails.mjs
+
+  pr-smoke:
+    name: PR Smoke Checks
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Run PR smoke checks
+        run: node scripts/ci/pr-smoke-checks.mjs

--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
     "dev": "node scripts/dev-server.mjs",
     "test": "vitest run",
     "test:watch": "vitest",
-    "test:coverage": "vitest run --coverage"
+    "test:coverage": "vitest run --coverage",
+    "check:sw-guardrails": "node scripts/ci/check-sw-guardrails.mjs",
+    "check:pr-smoke": "node scripts/ci/pr-smoke-checks.mjs"
   },
   "devDependencies": {
     "vitest": "^4.0.0"

--- a/scripts/ci/check-sw-guardrails.mjs
+++ b/scripts/ci/check-sw-guardrails.mjs
@@ -1,0 +1,86 @@
+import { readFileSync } from 'node:fs';
+import { execSync } from 'node:child_process';
+
+function getChangedFiles(baseSha, headSha) {
+  if (!baseSha || !headSha) {
+    console.log('No base/head SHAs provided, skipping service worker guardrail checks.');
+    return [];
+  }
+
+  const output = execSync(`git diff --name-only ${baseSha} ${headSha}`, {
+    encoding: 'utf8'
+  });
+
+  return output
+    .split('\n')
+    .map((file) => file.trim())
+    .filter(Boolean);
+}
+
+function parseStaticAssets(swContent) {
+  const match = swContent.match(/const\s+STATIC_ASSETS\s*=\s*\[(?<body>[\s\S]*?)\];/);
+  if (!match?.groups?.body) {
+    throw new Error('Unable to parse STATIC_ASSETS from sw.js');
+  }
+
+  const assets = new Set();
+  const stringRegex = /'([^']+)'/g;
+  let stringMatch = stringRegex.exec(match.groups.body);
+  while (stringMatch) {
+    assets.add(stringMatch[1]);
+    stringMatch = stringRegex.exec(match.groups.body);
+  }
+
+  return assets;
+}
+
+const baseSha = process.env.BASE_SHA;
+const headSha = process.env.HEAD_SHA;
+
+const changedFiles = getChangedFiles(baseSha, headSha);
+if (changedFiles.length === 0) {
+  process.exit(0);
+}
+
+const isContentFile = (file) => (
+  file.endsWith('.html') ||
+  file.endsWith('.js') ||
+  file.endsWith('.css') ||
+  file.startsWith('assets/')
+);
+
+const contentFilesChanged = changedFiles.filter(isContentFile);
+const pagesChanged = changedFiles.filter((file) => file.startsWith('pages/') && file.endsWith('.html'));
+
+const failures = [];
+
+if (contentFilesChanged.length > 0 && !changedFiles.includes('sw.js')) {
+  failures.push(
+    [
+      'HTML/JS/CSS/assets were changed but sw.js was not updated.',
+      'Please increment CACHE_VERSION in sw.js when site assets or source files change.'
+    ].join(' ')
+  );
+}
+
+if (pagesChanged.length > 0) {
+  const swContent = readFileSync('sw.js', 'utf8');
+  const staticAssets = parseStaticAssets(swContent);
+
+  for (const pageFile of pagesChanged) {
+    const route = `/${pageFile}`;
+    if (!staticAssets.has(route)) {
+      failures.push(`Changed page ${pageFile} is missing from STATIC_ASSETS in sw.js (${route}).`);
+    }
+  }
+}
+
+if (failures.length > 0) {
+  console.error('Service worker guardrail checks failed:\n');
+  for (const failure of failures) {
+    console.error(`- ${failure}`);
+  }
+  process.exit(1);
+}
+
+console.log('Service worker guardrail checks passed.');

--- a/scripts/ci/pr-smoke-checks.mjs
+++ b/scripts/ci/pr-smoke-checks.mjs
@@ -1,0 +1,86 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { execSync } from 'node:child_process';
+import { resolve } from 'node:path';
+
+function parseStaticAssets(swContent) {
+  const match = swContent.match(/const\s+STATIC_ASSETS\s*=\s*\[(?<body>[\s\S]*?)\];/);
+  if (!match?.groups?.body) {
+    throw new Error('Unable to parse STATIC_ASSETS from sw.js');
+  }
+
+  const assets = new Set();
+  const stringRegex = /'([^']+)'/g;
+  let stringMatch = stringRegex.exec(match.groups.body);
+  while (stringMatch) {
+    assets.add(stringMatch[1]);
+    stringMatch = stringRegex.exec(match.groups.body);
+  }
+
+  return assets;
+}
+
+function fileExistsFromWebPath(webPath) {
+  if (!webPath || webPath.startsWith('http://') || webPath.startsWith('https://') || webPath.startsWith('//')) {
+    return true;
+  }
+
+  if (webPath === '/' || webPath === '/nuclear') {
+    return true;
+  }
+
+  const normalized = decodeURIComponent(webPath).replace(/^\//, '');
+  return existsSync(resolve(normalized));
+}
+
+const failures = [];
+const swContent = readFileSync('sw.js', 'utf8');
+const staticAssets = parseStaticAssets(swContent);
+
+for (const assetPath of staticAssets) {
+  if (!fileExistsFromWebPath(assetPath)) {
+    failures.push(`STATIC_ASSETS entry does not exist: ${assetPath}`);
+  }
+}
+
+const pagePaths = execSync('find pages -maxdepth 1 -type f -name "*.html"', { encoding: 'utf8' })
+  .split('\n')
+  .map((file) => file.trim())
+  .filter(Boolean);
+
+const htmlFiles = ['index.html', ...pagePaths];
+
+const pageReferenceRegex = /\/pages\/[A-Za-z0-9._\-%]+\.html/g;
+for (const file of htmlFiles) {
+  const content = readFileSync(file, 'utf8');
+  const matches = content.match(pageReferenceRegex) ?? [];
+  for (const ref of matches) {
+    if (!existsSync(resolve(ref.slice(1)))) {
+      failures.push(`${file} references missing page: ${ref}`);
+    }
+  }
+}
+
+const pathAttrRegex = /(?:href|src)\s*=\s*"([^"#]+)"/g;
+for (const file of htmlFiles) {
+  const content = readFileSync(file, 'utf8');
+  let match = pathAttrRegex.exec(content);
+  while (match) {
+    const pathValue = match[1].trim();
+    const isAbsolutePath = pathValue.startsWith('/') && !pathValue.startsWith('/@');
+    const shouldValidatePath = isAbsolutePath && pathValue.includes('.');
+    if (shouldValidatePath && !fileExistsFromWebPath(pathValue)) {
+      failures.push(`${file} contains broken internal path: ${pathValue}`);
+    }
+    match = pathAttrRegex.exec(content);
+  }
+}
+
+if (failures.length > 0) {
+  console.error('PR smoke checks failed:\n');
+  for (const failure of failures) {
+    console.error(`- ${failure}`);
+  }
+  process.exit(1);
+}
+
+console.log('PR smoke checks passed.');

--- a/workers/router.test.js
+++ b/workers/router.test.js
@@ -1,0 +1,81 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import worker from './router.js';
+
+const makeResponse = (body = 'ok', status = 200) => new Response(body, { status });
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('workers/router', () => {
+  it('redirects /foo path requests to foo subdomain', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(makeResponse());
+
+    const request = new Request('https://bennyhartnett.com/contact?x=1');
+    const response = await worker.fetch(request, {}, {});
+
+    expect(response.status).toBe(301);
+    expect(response.headers.get('location')).toBe('https://contact.bennyhartnett.com/?x=1');
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('passes excluded paths through without redirect', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(makeResponse('asset'));
+
+    const request = new Request('https://bennyhartnett.com/js/spa-router.js');
+    const response = await worker.fetch(request, {}, {});
+
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe('asset');
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('serves nuclear and centrus subdomains from /nuclear.html', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(makeResponse('nuclear page'));
+
+    const nuclearResponse = await worker.fetch(new Request('https://nuclear.bennyhartnett.com/'), {}, {});
+    const centrusResponse = await worker.fetch(new Request('https://centrus.bennyhartnett.com/'), {}, {});
+
+    expect(nuclearResponse.status).toBe(200);
+    expect(centrusResponse.status).toBe(200);
+
+    const calledUrls = fetchSpy.mock.calls.map(([arg]) => String(arg));
+    expect(calledUrls).toContain('https://bennyhartnett.com/nuclear.html');
+  });
+
+  it('redirects thank-you subdomain to sent subdomain', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(makeResponse());
+
+    const response = await worker.fetch(new Request('https://thank-you.bennyhartnett.com/'), {}, {});
+
+    expect(response.status).toBe(301);
+    expect(response.headers.get('location')).toBe('https://sent.bennyhartnett.com/');
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('redirects ascii resume subdomain to canonical punycode idn', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(makeResponse());
+
+    const response = await worker.fetch(new Request('https://resume.bennyhartnett.com/'), {}, {});
+
+    expect(response.status).toBe(301);
+    expect(response.headers.get('location')).toBe('https://xn--rsum-bpad.bennyhartnett.com/');
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('serves card subdomain root as card.vcf with vcard headers', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response('VCARD', {
+      status: 200,
+      headers: {
+        'content-type': 'text/plain'
+      }
+    }));
+
+    const response = await worker.fetch(new Request('https://card.bennyhartnett.com/'), {}, {});
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('content-type')).toContain('text/vcard');
+    expect(response.headers.get('content-disposition')).toContain('Hartnett_Benny.vcf');
+    expect(await response.text()).toBe('VCARD');
+  });
+});


### PR DESCRIPTION
### Motivation
- Introduce automated quality gates to catch regressions before merging by validating unit tests, service-worker invariants, and basic PR smoke checks.
- Prevent stale service worker caches and missing page/assets references from being merged by enforcing `sw.js` consistency.

### Description
- Add a GitHub Actions workflow `quality-checks.yml` that runs `npm test`, service-worker guardrail checks, and PR smoke checks on `push` and `pull_request` to `main`.
- Add `scripts/ci/check-sw-guardrails.mjs` to detect changed HTML/JS/CSS/assets without `sw.js` updates and to ensure changed pages are listed in `STATIC_ASSETS` inside `sw.js`.
- Add `scripts/ci/pr-smoke-checks.mjs` to validate that entries in `STATIC_ASSETS` exist, that page references in HTML exist, and that absolute internal paths are not broken.
- Add `package.json` scripts `check:sw-guardrails` and `check:pr-smoke` and add a new `workers/router.test.js` Vitest unit test file covering routing behaviors and redirects.

### Testing
- Ran the unit test suite with `npm test` (Vitest) which exercised `workers/router.test.js` and completed successfully.
- Executed the guardrail scripts locally via `node scripts/ci/check-sw-guardrails.mjs` and `node scripts/ci/pr-smoke-checks.mjs` against the repository and they reported no failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e85d4d089c832da66d14b157bd3453)