### PR TITLE
docs: improve README discoverability and presentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,20 @@
 # bennyhartnett.com
 
+[![Live Site](https://img.shields.io/badge/Live%20Site-bennyhartnett.com-2ea44f?style=for-the-badge)](https://bennyhartnett.com)
+[![Tests](https://github.com/bennyhartnett/bennyhartnett.com/actions/workflows/test.yml/badge.svg)](https://github.com/bennyhartnett/bennyhartnett.com/actions/workflows/test.yml)
+[![Deploy to GitHub Pages](https://github.com/bennyhartnett/bennyhartnett.com/actions/workflows/gh-pages.yml/badge.svg)](https://github.com/bennyhartnett/bennyhartnett.com/actions/workflows/gh-pages.yml)
+[![License: Private](https://img.shields.io/badge/License-Private-red.svg)](#license)
+
 Personal portfolio site with subdomain-based routing, a PWA shell, and an isolated uranium enrichment calculator.
+
+## Live Website
+
+- **Production:** [https://bennyhartnett.com](https://bennyhartnett.com)
+- **Example subdomains:** [https://contact.bennyhartnett.com](https://contact.bennyhartnett.com), [https://nuclear.bennyhartnett.com](https://nuclear.bennyhartnett.com)
+
+## Preview
+
+![Portfolio homepage preview](assets/og-image.png)
 
 ## Architecture
 


### PR DESCRIPTION
### Motivation
- Improve README discoverability and make the live site, CI/deploy status, and a visual preview immediately visible so visitors and contributors can find the deployed portfolio and project status quickly.

### Description
- Add a prominent live-site badge linking to `https://bennyhartnett.com`, CI/deploy/license badges, a `Live Website` section with production and example subdomain links, and a `Preview` section embedding `assets/og-image.png` into `README.md`.

### Testing
- Run `npm test` which executed `nuclear/nuclear-math.test.js` (56 tests) and passed (56/56).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e85f18b6d4832d9c08b14cfa6f3817)