### PR TITLE
Make resume page background more transparent

### DIFF
--- a/pages/resume.html
+++ b/pages/resume.html
@@ -101,7 +101,7 @@
   }
   /* Dark mode styles for PDF */
   .pdf-pages.dark-mode {
-    background: rgba(255, 255, 255, 0.06);
+    background: rgba(255, 255, 255, 0.04);
     backdrop-filter: blur(12px);
     -webkit-backdrop-filter: blur(12px);
     border: 1px solid rgba(255, 255, 255, 0.15);
@@ -138,7 +138,7 @@
   }
   .pdf-pages {
     box-shadow: 0 2px 10px rgba(0,0,0,0.3);
-    background: rgba(255, 255, 255, 0.15);
+    background: rgba(255, 255, 255, 0.08);
     backdrop-filter: blur(12px);
     -webkit-backdrop-filter: blur(12px);
     border-radius: 6px;

--- a/sw.js
+++ b/sw.js
@@ -1,6 +1,6 @@
 // Service Worker for SWU Calculator PWA
 // Version must be updated when deploying new code to bust cache
-const CACHE_VERSION = 'v137';
+const CACHE_VERSION = 'v138';
 const CACHE_NAME = `swu-calculator-${CACHE_VERSION}`;
 
 // Files to cache for offline use


### PR DESCRIPTION
### Motivation

- Improve visual transparency of the résumé viewer so the site's Three.js wave background shows through more clearly.
- Keep the same relative transparency behavior in dark mode so the visual change is consistent across themes.
- Ensure clients receive the updated styles by invalidating the service worker cache.

### Description

- Reduced the light-mode resume container background opacity in `pages/resume.html` by changing `.pdf-pages` background to `rgba(255, 255, 255, 0.08)`.
- Reduced the dark-mode resume container background opacity in `pages/resume.html` by changing `.pdf-pages.dark-mode` background to `rgba(255, 255, 255, 0.04)`.
- Bumped the service worker `CACHE_VERSION` in `sw.js` from `v137` to `v138` so clients will fetch the updated stylesheet.

### Testing

- Ran `npm test` (Vitest): all automated tests passed (`2` test files, `62` tests total).
- No visual/browser screenshots available in this environment; change is a CSS tweak and validated via local tests only.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8601a16a0832db191fdc4ec7c27b3)