### PR TITLE
Remove duplicate Coming Soon card and bump service worker cache version

### DIFF
--- a/pages/tools.html
+++ b/pages/tools.html
@@ -260,14 +260,6 @@
       <span class="tool-tag">Coming Soon</span>
     </div>
 
-    <div class="tool-card coming-soon">
-      <div class="tool-header">
-        <span class="tool-icon"><svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M11.42 15.17 17.25 21A2.652 2.652 0 0 0 21 17.25l-5.877-5.877M11.42 15.17l2.496-3.03c.317-.384.74-.626 1.208-.766M11.42 15.17l-4.655 5.653a2.548 2.548 0 1 1-3.586-3.586l6.837-5.63m5.108-.233c.55-.164 1.163-.188 1.743-.14a4.5 4.5 0 0 0 4.486-6.336l-3.276 3.277a3.004 3.004 0 0 1-2.25-2.25l3.276-3.276a4.5 4.5 0 0 0-6.336 4.486c.091 1.076-.071 2.264-.904 2.95l-.102.085m-1.745 1.437L5.909 7.5H4.5L2.25 3.75l1.5-1.5L7.5 4.5v1.409l4.26 4.26m-1.745 1.437 1.745-1.437m6.615 8.206L15.75 15.75M4.867 19.125h.008v.008h-.008v-.008Z" /></svg></span>
-        <h2>Coming Soon</h2>
-      </div>
-      <p>More tools are on the way. Check back for updates.</p>
-      <span class="tool-tag">Coming Soon</span>
-    </div>
   </div>
 </div>
 

--- a/sw.js
+++ b/sw.js
@@ -1,6 +1,6 @@
 // Service Worker for SWU Calculator PWA
 // Version must be updated when deploying new code to bust cache
-const CACHE_VERSION = 'v137';
+const CACHE_VERSION = 'v138';
 const CACHE_NAME = `swu-calculator-${CACHE_VERSION}`;
 
 // Files to cache for offline use


### PR DESCRIPTION
### Motivation
- Remove a duplicated "Coming Soon" placeholder in the tools grid to avoid a redundant UI entry and ensure a single placeholder remains, and update the service worker cache to propagate the HTML change.

### Description
- Deleted the duplicate tool card block from `pages/tools.html` so only one "Coming Soon" card is displayed.
- Incremented `CACHE_VERSION` in `sw.js` from `v137` to `v138` to force a cache refresh after the HTML update.

### Testing
- Ran `npm test` (Vitest), which ran 2 test files and reported all tests passing: 62 passed (62).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e862eb6900832db37cb1ad29115e2e)