### PR TITLE
Add unit tests, test hooks, and testable CI smoke/guardrail scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,9 +54,29 @@ No build step required.
 npm test              # Run tests once (vitest)
 npm run test:watch    # Watch mode
 npm run test:coverage # With coverage
+npm run check:sw-guardrails # Service worker cache guardrails (CI helper)
+npm run check:pr-smoke      # Broken-link and static asset smoke checks
 ```
 
-Tests live in `nuclear/nuclear-math.test.js` and cover the enrichment math functions. CI runs on every push/PR to `main` via `.github/workflows/test.yml`.
+### Test Suites
+
+- `nuclear/nuclear-math.test.js` — Uranium enrichment math, mode consistency, and edge cases.
+- `workers/router.test.js` — Cloudflare worker routing and redirect behavior.
+- `sw.test.js` — Service worker lifecycle + fetch strategy behavior.
+- `js/spa-router.test.js` — SPA route selection and link-handling redirects.
+- `scripts/ci/check-sw-guardrails.test.js` — Cache-version/page-asset guardrail logic.
+- `scripts/ci/pr-smoke-checks.test.js` — Broken link/static asset smoke-check logic.
+
+### Current Local Status (2026-04-22)
+
+| Command | Status | Notes |
+|---|---|---|
+| `npm test` | ✅ Pass | All suites passing locally. |
+| `npm run check:sw-guardrails` | ✅ Pass* | Passes when no `BASE_SHA`/`HEAD_SHA` are provided (expected local behavior). |
+| `npm run check:pr-smoke` | ✅ Pass | Internal asset/page checks pass. |
+| `npm run test:coverage` | ❌ Fail | Missing dev dependency `@vitest/coverage-v8`. |
+
+CI runs on every push/PR to `main` via `.github/workflows/test.yml`.
 
 ## Deployment
 

--- a/js/spa-router.js
+++ b/js/spa-router.js
@@ -457,3 +457,11 @@ export function initRouter() {
     });
   }
 }
+
+// Test hooks for unit tests in non-browser environments.
+export const __test__ = {
+  getRootDomain,
+  getInitialPage,
+  handleLinkClick,
+  isSubdomain
+};

--- a/js/spa-router.test.js
+++ b/js/spa-router.test.js
@@ -1,0 +1,176 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('./meta-manager.js', () => ({
+  updateMetaTags: vi.fn(),
+  getMetaMap: vi.fn(() => ({
+    'pages/home.html': { title: 'Home' }
+  })),
+  getBaseOgImage: vi.fn(() => '/assets/og-image.png')
+}));
+
+vi.mock('./analytics.js', () => ({
+  trackPageView: vi.fn()
+}));
+
+vi.mock('./performance-profile.js', () => ({
+  getPerformanceProfile: vi.fn(() => ({
+    prefetchPages: false,
+    heavyWorkDelayMs: 0,
+    maxPrefetchPages: 0
+  })),
+  scheduleDeferredTask: vi.fn()
+}));
+
+import { __test__ } from './spa-router.js';
+
+function makeLink({ href, dataHref, external } = {}) {
+  return {
+    dataset: {
+      external: external ? 'true' : undefined
+    },
+    getAttribute(name) {
+      if (name === 'href') return href ?? null;
+      if (name === 'data-href') return dataHref ?? null;
+      return null;
+    }
+  };
+}
+
+describe('js/spa-router', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+
+    globalThis.location = {
+      hostname: 'bennyhartnett.com',
+      pathname: '/',
+      hash: ''
+    };
+
+    globalThis.window = {
+      location: {
+        href: 'https://bennyhartnett.com'
+      },
+      open: vi.fn()
+    };
+
+    const storage = new Map();
+    globalThis.sessionStorage = {
+      getItem: vi.fn((key) => storage.get(key) ?? null),
+      setItem: vi.fn((key, value) => storage.set(key, value)),
+      removeItem: vi.fn((key) => storage.delete(key))
+    };
+  });
+
+  it('uses matching root domain for bennyhartnett.com hosts', () => {
+    globalThis.location.hostname = 'contact.bennyhartnett.com';
+
+    expect(__test__.getRootDomain()).toBe('bennyhartnett.com');
+  });
+
+  it('uses matching root domain for federalinnovations.com hosts', () => {
+    globalThis.location.hostname = 'www.federalinnovations.com';
+
+    expect(__test__.getRootDomain()).toBe('federalinnovations.com');
+  });
+
+  it('resolves IDN subdomain aliases in initial route selection', () => {
+    globalThis.location.hostname = 'xn--rsum-bpad.bennyhartnett.com';
+
+    expect(__test__.getInitialPage()).toBe('pages/resume.html');
+  });
+
+  it('uses sessionStorage spa-redirect when present', () => {
+    sessionStorage.setItem('spa-redirect', 'projects');
+
+    expect(__test__.getInitialPage()).toBe('pages/projects.html');
+    expect(sessionStorage.removeItem).toHaveBeenCalledWith('spa-redirect');
+  });
+
+  it('uses clean pathname when provided', () => {
+    globalThis.location.pathname = '/contact';
+
+    expect(__test__.getInitialPage()).toBe('pages/contact.html');
+  });
+
+  it('uses hash fallback when pathname is root', () => {
+    globalThis.location.hash = '#tools';
+
+    expect(__test__.getInitialPage()).toBe('pages/tools');
+  });
+
+  it('opens external links in a new tab', () => {
+    const link = makeLink({ href: 'https://example.com', external: true });
+    const event = {
+      target: { closest: vi.fn((selector) => (selector === 'a' ? link : null)) },
+      preventDefault: vi.fn()
+    };
+
+    __test__.handleLinkClick(event);
+
+    expect(event.preventDefault).toHaveBeenCalled();
+    expect(window.open).toHaveBeenCalledWith('https://example.com', '_blank', 'noopener');
+  });
+
+  it('redirects nuclear links to the nuclear subdomain', () => {
+    const link = makeLink({ href: '/nuclear' });
+    const event = {
+      target: { closest: vi.fn((selector) => (selector === 'a' ? link : null)) },
+      preventDefault: vi.fn()
+    };
+
+    __test__.handleLinkClick(event);
+
+    expect(event.preventDefault).toHaveBeenCalled();
+    expect(window.location.href).toBe('https://nuclear.bennyhartnett.com');
+  });
+
+  it('redirects home links to root domain', () => {
+    globalThis.location.hostname = 'contact.bennyhartnett.com';
+    const link = makeLink({ href: '/home' });
+    const event = {
+      target: { closest: vi.fn((selector) => (selector === 'a' ? link : null)) },
+      preventDefault: vi.fn()
+    };
+
+    __test__.handleLinkClick(event);
+
+    expect(window.location.href).toBe('https://bennyhartnett.com');
+  });
+
+  it('redirects clean route links to canonical subdomains', () => {
+    const link = makeLink({ href: '/projects' });
+    const event = {
+      target: { closest: vi.fn((selector) => (selector === 'a' ? link : null)) },
+      preventDefault: vi.fn()
+    };
+
+    __test__.handleLinkClick(event);
+
+    expect(window.location.href).toBe('https://projects.bennyhartnett.com');
+  });
+
+  it('redirects resume route links to IDN subdomain', () => {
+    const link = makeLink({ href: '/resume' });
+    const event = {
+      target: { closest: vi.fn((selector) => (selector === 'a' ? link : null)) },
+      preventDefault: vi.fn()
+    };
+
+    __test__.handleLinkClick(event);
+
+    expect(window.location.href).toBe('https://xn--rsum-bpad.bennyhartnett.com');
+  });
+
+  it('does not intercept excluded asset paths', () => {
+    const link = makeLink({ href: '/css/main.css' });
+    const event = {
+      target: { closest: vi.fn((selector) => (selector === 'a' ? link : null)) },
+      preventDefault: vi.fn()
+    };
+
+    __test__.handleLinkClick(event);
+
+    expect(event.preventDefault).not.toHaveBeenCalled();
+    expect(window.location.href).toBe('https://bennyhartnett.com');
+  });
+});

--- a/scripts/ci/check-sw-guardrails.mjs
+++ b/scripts/ci/check-sw-guardrails.mjs
@@ -1,7 +1,7 @@
 import { readFileSync } from 'node:fs';
 import { execSync } from 'node:child_process';
 
-function getChangedFiles(baseSha, headSha) {
+export function getChangedFiles(baseSha, headSha) {
   if (!baseSha || !headSha) {
     console.log('No base/head SHAs provided, skipping service worker guardrail checks.');
     return [];
@@ -17,7 +17,7 @@ function getChangedFiles(baseSha, headSha) {
     .filter(Boolean);
 }
 
-function parseStaticAssets(swContent) {
+export function parseStaticAssets(swContent) {
   const match = swContent.match(/const\s+STATIC_ASSETS\s*=\s*\[(?<body>[\s\S]*?)\];/);
   if (!match?.groups?.body) {
     throw new Error('Unable to parse STATIC_ASSETS from sw.js');
@@ -34,14 +34,6 @@ function parseStaticAssets(swContent) {
   return assets;
 }
 
-const baseSha = process.env.BASE_SHA;
-const headSha = process.env.HEAD_SHA;
-
-const changedFiles = getChangedFiles(baseSha, headSha);
-if (changedFiles.length === 0) {
-  process.exit(0);
-}
-
 const isContentFile = (file) => (
   file.endsWith('.html') ||
   file.endsWith('.js') ||
@@ -49,38 +41,56 @@ const isContentFile = (file) => (
   file.startsWith('assets/')
 );
 
-const contentFilesChanged = changedFiles.filter(isContentFile);
-const pagesChanged = changedFiles.filter((file) => file.startsWith('pages/') && file.endsWith('.html'));
+export function runCheckSwGuardrails(changedFiles, swContent = readFileSync('sw.js', 'utf8')) {
+  const contentFilesChanged = changedFiles.filter(isContentFile);
+  const pagesChanged = changedFiles.filter((file) => file.startsWith('pages/') && file.endsWith('.html'));
+  const failures = [];
 
-const failures = [];
+  if (contentFilesChanged.length > 0 && !changedFiles.includes('sw.js')) {
+    failures.push(
+      [
+        'HTML/JS/CSS/assets were changed but sw.js was not updated.',
+        'Please increment CACHE_VERSION in sw.js when site assets or source files change.'
+      ].join(' ')
+    );
+  }
 
-if (contentFilesChanged.length > 0 && !changedFiles.includes('sw.js')) {
-  failures.push(
-    [
-      'HTML/JS/CSS/assets were changed but sw.js was not updated.',
-      'Please increment CACHE_VERSION in sw.js when site assets or source files change.'
-    ].join(' ')
-  );
-}
+  if (pagesChanged.length > 0) {
+    const staticAssets = parseStaticAssets(swContent);
 
-if (pagesChanged.length > 0) {
-  const swContent = readFileSync('sw.js', 'utf8');
-  const staticAssets = parseStaticAssets(swContent);
-
-  for (const pageFile of pagesChanged) {
-    const route = `/${pageFile}`;
-    if (!staticAssets.has(route)) {
-      failures.push(`Changed page ${pageFile} is missing from STATIC_ASSETS in sw.js (${route}).`);
+    for (const pageFile of pagesChanged) {
+      const route = `/${pageFile}`;
+      if (!staticAssets.has(route)) {
+        failures.push(`Changed page ${pageFile} is missing from STATIC_ASSETS in sw.js (${route}).`);
+      }
     }
   }
+
+  return failures;
 }
 
-if (failures.length > 0) {
-  console.error('Service worker guardrail checks failed:\n');
-  for (const failure of failures) {
-    console.error(`- ${failure}`);
+export function main() {
+  const baseSha = process.env.BASE_SHA;
+  const headSha = process.env.HEAD_SHA;
+  const changedFiles = getChangedFiles(baseSha, headSha);
+
+  if (changedFiles.length === 0) {
+    process.exit(0);
   }
-  process.exit(1);
+
+  const failures = runCheckSwGuardrails(changedFiles);
+
+  if (failures.length > 0) {
+    console.error('Service worker guardrail checks failed:\n');
+    for (const failure of failures) {
+      console.error(`- ${failure}`);
+    }
+    process.exit(1);
+  }
+
+  console.log('Service worker guardrail checks passed.');
 }
 
-console.log('Service worker guardrail checks passed.');
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/scripts/ci/check-sw-guardrails.test.js
+++ b/scripts/ci/check-sw-guardrails.test.js
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import { parseStaticAssets, runCheckSwGuardrails } from './check-sw-guardrails.mjs';
+
+describe('scripts/ci/check-sw-guardrails', () => {
+  it('parses static assets entries from sw.js content', () => {
+    const assets = parseStaticAssets("const STATIC_ASSETS = ['/', '/pages/home.html'];");
+
+    expect(assets.has('/')).toBe(true);
+    expect(assets.has('/pages/home.html')).toBe(true);
+  });
+
+  it('fails when content files changed without sw.js update', () => {
+    const failures = runCheckSwGuardrails(['js/spa-router.js']);
+
+    expect(failures).toHaveLength(1);
+    expect(failures[0]).toContain('sw.js was not updated');
+  });
+
+  it('fails when changed pages are missing from STATIC_ASSETS', () => {
+    const failures = runCheckSwGuardrails(
+      ['pages/new-page.html', 'sw.js'],
+      "const STATIC_ASSETS = ['/', '/pages/home.html'];"
+    );
+
+    expect(failures).toHaveLength(1);
+    expect(failures[0]).toContain('/pages/new-page.html');
+  });
+
+  it('passes when changed page is present and sw.js changed', () => {
+    const failures = runCheckSwGuardrails(
+      ['pages/home.html', 'sw.js'],
+      "const STATIC_ASSETS = ['/', '/pages/home.html'];"
+    );
+
+    expect(failures).toEqual([]);
+  });
+});

--- a/scripts/ci/pr-smoke-checks.mjs
+++ b/scripts/ci/pr-smoke-checks.mjs
@@ -2,7 +2,7 @@ import { existsSync, readFileSync } from 'node:fs';
 import { execSync } from 'node:child_process';
 import { resolve } from 'node:path';
 
-function parseStaticAssets(swContent) {
+export function parseStaticAssets(swContent) {
   const match = swContent.match(/const\s+STATIC_ASSETS\s*=\s*\[(?<body>[\s\S]*?)\];/);
   if (!match?.groups?.body) {
     throw new Error('Unable to parse STATIC_ASSETS from sw.js');
@@ -19,7 +19,7 @@ function parseStaticAssets(swContent) {
   return assets;
 }
 
-function fileExistsFromWebPath(webPath) {
+export function fileExistsFromWebPath(webPath, exists = existsSync) {
   if (!webPath || webPath.startsWith('http://') || webPath.startsWith('https://') || webPath.startsWith('//')) {
     return true;
   }
@@ -29,58 +29,71 @@ function fileExistsFromWebPath(webPath) {
   }
 
   const normalized = decodeURIComponent(webPath).replace(/^\//, '');
-  return existsSync(resolve(normalized));
+  return exists(resolve(normalized));
 }
 
-const failures = [];
-const swContent = readFileSync('sw.js', 'utf8');
-const staticAssets = parseStaticAssets(swContent);
+export function runPrSmokeChecks({
+  swContent = readFileSync('sw.js', 'utf8'),
+  pagePaths = execSync('find pages -maxdepth 1 -type f -name "*.html"', { encoding: 'utf8' })
+    .split('\n')
+    .map((file) => file.trim())
+    .filter(Boolean),
+  readFile = readFileSync,
+  exists = existsSync
+} = {}) {
+  const failures = [];
+  const staticAssets = parseStaticAssets(swContent);
 
-for (const assetPath of staticAssets) {
-  if (!fileExistsFromWebPath(assetPath)) {
-    failures.push(`STATIC_ASSETS entry does not exist: ${assetPath}`);
-  }
-}
-
-const pagePaths = execSync('find pages -maxdepth 1 -type f -name "*.html"', { encoding: 'utf8' })
-  .split('\n')
-  .map((file) => file.trim())
-  .filter(Boolean);
-
-const htmlFiles = ['index.html', ...pagePaths];
-
-const pageReferenceRegex = /\/pages\/[A-Za-z0-9._\-%]+\.html/g;
-for (const file of htmlFiles) {
-  const content = readFileSync(file, 'utf8');
-  const matches = content.match(pageReferenceRegex) ?? [];
-  for (const ref of matches) {
-    if (!existsSync(resolve(ref.slice(1)))) {
-      failures.push(`${file} references missing page: ${ref}`);
+  for (const assetPath of staticAssets) {
+    if (!fileExistsFromWebPath(assetPath, exists)) {
+      failures.push(`STATIC_ASSETS entry does not exist: ${assetPath}`);
     }
   }
-}
 
-const pathAttrRegex = /(?:href|src)\s*=\s*"([^"#]+)"/g;
-for (const file of htmlFiles) {
-  const content = readFileSync(file, 'utf8');
-  let match = pathAttrRegex.exec(content);
-  while (match) {
-    const pathValue = match[1].trim();
-    const isAbsolutePath = pathValue.startsWith('/') && !pathValue.startsWith('/@');
-    const shouldValidatePath = isAbsolutePath && pathValue.includes('.');
-    if (shouldValidatePath && !fileExistsFromWebPath(pathValue)) {
-      failures.push(`${file} contains broken internal path: ${pathValue}`);
+  const htmlFiles = ['index.html', ...pagePaths];
+
+  const pageReferenceRegex = /\/pages\/[A-Za-z0-9._\-%]+\.html/g;
+  for (const file of htmlFiles) {
+    const content = readFile(file, 'utf8');
+    const matches = content.match(pageReferenceRegex) ?? [];
+    for (const ref of matches) {
+      if (!exists(resolve(ref.slice(1)))) {
+        failures.push(`${file} references missing page: ${ref}`);
+      }
     }
-    match = pathAttrRegex.exec(content);
   }
+
+  const pathAttrRegex = /(?:href|src)\s*=\s*"([^"#]+)"/g;
+  for (const file of htmlFiles) {
+    const content = readFile(file, 'utf8');
+    let match = pathAttrRegex.exec(content);
+    while (match) {
+      const pathValue = match[1].trim();
+      const isAbsolutePath = pathValue.startsWith('/') && !pathValue.startsWith('/@');
+      const shouldValidatePath = isAbsolutePath && pathValue.includes('.');
+      if (shouldValidatePath && !fileExistsFromWebPath(pathValue, exists)) {
+        failures.push(`${file} contains broken internal path: ${pathValue}`);
+      }
+      match = pathAttrRegex.exec(content);
+    }
+  }
+
+  return failures;
 }
 
-if (failures.length > 0) {
-  console.error('PR smoke checks failed:\n');
-  for (const failure of failures) {
-    console.error(`- ${failure}`);
+export function main() {
+  const failures = runPrSmokeChecks();
+  if (failures.length > 0) {
+    console.error('PR smoke checks failed:\n');
+    for (const failure of failures) {
+      console.error(`- ${failure}`);
+    }
+    process.exit(1);
   }
-  process.exit(1);
+
+  console.log('PR smoke checks passed.');
 }
 
-console.log('PR smoke checks passed.');
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/scripts/ci/pr-smoke-checks.test.js
+++ b/scripts/ci/pr-smoke-checks.test.js
@@ -1,0 +1,68 @@
+import { describe, expect, it, vi } from 'vitest';
+import { fileExistsFromWebPath, parseStaticAssets, runPrSmokeChecks } from './pr-smoke-checks.mjs';
+
+describe('scripts/ci/pr-smoke-checks', () => {
+  it('parses static assets entries from service worker content', () => {
+    const assets = parseStaticAssets("const STATIC_ASSETS = ['/', '/css/main.css'];");
+
+    expect(assets.has('/')).toBe(true);
+    expect(assets.has('/css/main.css')).toBe(true);
+  });
+
+  it('treats absolute external and root paths as existing', () => {
+    expect(fileExistsFromWebPath('https://example.com/file.js')).toBe(true);
+    expect(fileExistsFromWebPath('/')).toBe(true);
+    expect(fileExistsFromWebPath('/nuclear')).toBe(true);
+  });
+
+  it('reports missing static assets from STATIC_ASSETS', () => {
+    const exists = vi.fn((path) => path.endsWith('index.html'));
+    const readFile = vi.fn((file) => {
+      if (file === 'index.html') return '<a href="/missing.css"></a>';
+      return '';
+    });
+
+    const failures = runPrSmokeChecks({
+      swContent: "const STATIC_ASSETS = ['/', '/missing.css'];",
+      pagePaths: [],
+      readFile,
+      exists
+    });
+
+    expect(failures.some((failure) => failure.includes('STATIC_ASSETS entry does not exist: /missing.css'))).toBe(true);
+  });
+
+  it('reports broken page references and broken internal links', () => {
+    const exists = vi.fn((path) => path.endsWith('index.html'));
+    const readFile = vi.fn((file) => {
+      if (file === 'index.html') {
+        return '<script src="/js/missing.js"></script><a href="/pages/missing.html">Missing</a>';
+      }
+      return '';
+    });
+
+    const failures = runPrSmokeChecks({
+      swContent: "const STATIC_ASSETS = ['/', '/index.html'];",
+      pagePaths: [],
+      readFile,
+      exists
+    });
+
+    expect(failures.some((failure) => failure.includes('references missing page: /pages/missing.html'))).toBe(true);
+    expect(failures.some((failure) => failure.includes('contains broken internal path: /js/missing.js'))).toBe(true);
+  });
+
+  it('passes when assets and references exist', () => {
+    const exists = vi.fn(() => true);
+    const readFile = vi.fn(() => '<a href="/css/main.css">CSS</a>');
+
+    const failures = runPrSmokeChecks({
+      swContent: "const STATIC_ASSETS = ['/', '/css/main.css'];",
+      pagePaths: ['pages/home.html'],
+      readFile,
+      exists
+    });
+
+    expect(failures).toEqual([]);
+  });
+});

--- a/sw.test.js
+++ b/sw.test.js
@@ -1,0 +1,150 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+let handlers;
+
+function makeInstallEvent() {
+  const waits = [];
+  return {
+    waits,
+    waitUntil(promise) {
+      waits.push(promise);
+    }
+  };
+}
+
+function makeFetchEvent(request) {
+  let responsePromise;
+  return {
+    request,
+    respondWith(promise) {
+      responsePromise = promise;
+    },
+    get responsePromise() {
+      return responsePromise;
+    }
+  };
+}
+
+describe('sw.js service worker', () => {
+  beforeEach(async () => {
+    vi.resetModules();
+    vi.restoreAllMocks();
+
+    handlers = {};
+
+    globalThis.self = {
+      location: { origin: 'https://bennyhartnett.com' },
+      clients: { claim: vi.fn(() => Promise.resolve()) },
+      skipWaiting: vi.fn(() => Promise.resolve()),
+      addEventListener: vi.fn((type, handler) => {
+        handlers[type] = handler;
+      })
+    };
+
+    const cacheStore = new Map();
+    const activeCache = {
+      addAll: vi.fn(() => Promise.resolve()),
+      put: vi.fn(() => Promise.resolve())
+    };
+
+    globalThis.caches = {
+      open: vi.fn(() => Promise.resolve(activeCache)),
+      keys: vi.fn(() => Promise.resolve(['swu-calculator-v136', 'swu-calculator-v137'])),
+      delete: vi.fn(() => Promise.resolve(true)),
+      match: vi.fn((request) => Promise.resolve(cacheStore.get(String(request.url ?? request)) ?? undefined)),
+      __cacheStore: cacheStore,
+      __activeCache: activeCache
+    };
+
+    globalThis.fetch = vi.fn((request) => Promise.resolve(new Response('network', { status: 200 })));
+
+    await import('./sw.js');
+  });
+
+  it('registers install, activate, fetch, and message handlers', () => {
+    expect(typeof handlers.install).toBe('function');
+    expect(typeof handlers.activate).toBe('function');
+    expect(typeof handlers.fetch).toBe('function');
+    expect(typeof handlers.message).toBe('function');
+  });
+
+  it('caches static assets on install and calls skipWaiting', async () => {
+    const event = makeInstallEvent();
+    handlers.install(event);
+    await Promise.all(event.waits);
+
+    expect(caches.open).toHaveBeenCalledTimes(1);
+    expect(caches.__activeCache.addAll).toHaveBeenCalledTimes(1);
+    expect(self.skipWaiting).toHaveBeenCalledTimes(1);
+  });
+
+  it('deletes old versioned caches on activate and claims clients', async () => {
+    const event = makeInstallEvent();
+    handlers.activate(event);
+    await Promise.all(event.waits);
+
+    expect(caches.delete).toHaveBeenCalledWith('swu-calculator-v136');
+    expect(caches.delete).not.toHaveBeenCalledWith('swu-calculator-v137');
+    expect(self.clients.claim).toHaveBeenCalledTimes(1);
+  });
+
+  it('ignores non-GET fetch requests', () => {
+    const event = makeFetchEvent(new Request('https://bennyhartnett.com/pages/home.html', { method: 'POST' }));
+    handlers.fetch(event);
+
+    expect(event.responsePromise).toBeUndefined();
+  });
+
+  it('uses cache-first strategy for approved CDN origins', async () => {
+    const request = new Request('https://cdnjs.cloudflare.com/ajax/libs/three.js/r1/three.min.js');
+    const event = makeFetchEvent(request);
+    handlers.fetch(event);
+
+    const response = await event.responsePromise;
+    expect(response.status).toBe(200);
+    expect(fetch).toHaveBeenCalledWith(request);
+    expect(caches.open).toHaveBeenCalled();
+    expect(caches.__activeCache.put).toHaveBeenCalled();
+  });
+
+  it('bypasses non-whitelisted external origins', () => {
+    const request = new Request('https://example.com/script.js');
+    const event = makeFetchEvent(request);
+    handlers.fetch(event);
+
+    expect(event.responsePromise).toBeUndefined();
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it('uses network-first strategy for HTML and falls back to cache on failure', async () => {
+    const request = new Request('https://bennyhartnett.com/pages/contact.html');
+    const cached = new Response('cached contact', { status: 200 });
+    caches.__cacheStore.set(request.url, cached);
+
+    fetch.mockRejectedValueOnce(new Error('offline'));
+
+    const event = makeFetchEvent(request);
+    handlers.fetch(event);
+    const response = await event.responsePromise;
+
+    expect(await response.text()).toBe('cached contact');
+  });
+
+  it('uses cache-first strategy for same-origin assets', async () => {
+    const request = new Request('https://bennyhartnett.com/assets/logo.png');
+    fetch.mockResolvedValueOnce(new Response('image bytes', { status: 200 }));
+
+    const event = makeFetchEvent(request);
+    handlers.fetch(event);
+
+    const response = await event.responsePromise;
+    expect(await response.text()).toBe('image bytes');
+    expect(caches.__activeCache.put).toHaveBeenCalled();
+  });
+
+  it('handles skipWaiting message', () => {
+    handlers.message({ data: 'skipWaiting' });
+
+    expect(self.skipWaiting).toHaveBeenCalledTimes(1);
+  });
+});

--- a/workers/router.test.js
+++ b/workers/router.test.js
@@ -8,6 +8,33 @@ afterEach(() => {
 });
 
 describe('workers/router', () => {
+  it('passes through requests marked as internal worker fetches', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(makeResponse('internal'));
+
+    const request = new Request('https://bennyhartnett.com/contact', {
+      headers: {
+        'X-CF-Worker-Internal': '1'
+      }
+    });
+    const response = await worker.fetch(request, {}, {});
+
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe('internal');
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(String(fetchSpy.mock.calls[0][0])).toBe(String(request));
+  });
+
+  it('passes unsupported domains through without redirect', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(makeResponse('external'));
+
+    const request = new Request('https://example.com/contact');
+    const response = await worker.fetch(request, {}, {});
+
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe('external');
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
   it('redirects /foo path requests to foo subdomain', async () => {
     const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(makeResponse());
 
@@ -28,6 +55,54 @@ describe('workers/router', () => {
     expect(response.status).toBe(200);
     expect(await response.text()).toBe('asset');
     expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('passes non-html file paths through on main domain', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(makeResponse('file passthrough'));
+
+    const request = new Request('https://bennyhartnett.com/favicon.svg');
+    const response = await worker.fetch(request, {}, {});
+
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe('file passthrough');
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('strips .html extension on path redirects', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(makeResponse());
+
+    const request = new Request('https://bennyhartnett.com/projects.html?tab=all');
+    const response = await worker.fetch(request, {}, {});
+
+    expect(response.status).toBe(301);
+    expect(response.headers.get('location')).toBe('https://projects.bennyhartnett.com/?tab=all');
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('supports federalinnovations.com root domain redirects', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(makeResponse());
+
+    const request = new Request('https://federalinnovations.com/contact');
+    const response = await worker.fetch(request, {}, {});
+
+    expect(response.status).toBe(301);
+    expect(response.headers.get('location')).toBe('https://contact.federalinnovations.com/');
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('passes static assets on subdomains through main domain with internal header', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(makeResponse('asset ok'));
+
+    const response = await worker.fetch(new Request('https://contact.bennyhartnett.com/css/main.css'), {}, {});
+
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe('asset ok');
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+
+    const [url, init] = fetchSpy.mock.calls[0];
+    expect(String(url)).toBe('https://bennyhartnett.com/css/main.css');
+    expect(init.method).toBe('GET');
+    expect(init.headers.get('X-CF-Worker-Internal')).toBe('1');
   });
 
   it('serves nuclear and centrus subdomains from /nuclear.html', async () => {


### PR DESCRIPTION
### Motivation

- Make core runtime logic and CI helper scripts unit-testable to catch regressions early.
- Provide automated smoke and guardrail checks for service-worker asset coverage and broken internal links.
- Expose small hooks from the SPA router to enable headless testing of routing behavior.

### Description

- Added unit tests for SPA routing (`js/spa-router.test.js`), service worker behavior (`sw.test.js`), worker routing (`workers/router.test.js` updates), and CI helpers (`scripts/ci/check-sw-guardrails.test.js` and `scripts/ci/pr-smoke-checks.test.js`).
- Exported internal helpers from `scripts/ci/check-sw-guardrails.mjs` and refactored it to `parseStaticAssets`, `runCheckSwGuardrails`, and `main` for programmatic testing and CLI invocation, with a file-level `main()` guard.
- Refactored `scripts/ci/pr-smoke-checks.mjs` to export `parseStaticAssets`, `fileExistsFromWebPath`, `runPrSmokeChecks`, and `main`, and parameterized filesystem calls so tests can inject mocks.
- Added `__test__` exports to `js/spa-router.js` exposing `getRootDomain`, `getInitialPage`, `handleLinkClick`, and `isSubdomain` to drive unit tests, and updated `README.md` to document the new test suites and local status commands.

### Testing

- Ran `npm test` which runs the unit suites locally and reports all suites passing.
- Ran `npm run check:sw-guardrails` and `npm run check:pr-smoke` which pass locally under normal conditions as documented in `README.md`.
- Ran `npm run test:coverage` which failed due to a missing dev dependency `@vitest/coverage-v8` and is documented in the README status table.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e85fec42e4832db05a45d41523b311)