### PR TITLE
Improve LLM discovery: add root llms entrypoints, allowlist ChatGPT Search bot, and update sitemap

### DIFF
--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1,0 +1,6 @@
+# llms-full.txt (canonical path)
+
+Canonical detailed profile file:
+https://bennyhartnett.com/config/llms-full.txt
+
+If your crawler or agent expects `/llms-full.txt` at root, use this file as the stable entrypoint and then fetch the canonical file above.

--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,10 @@
+# llms.txt (canonical path)
+
+This file mirrors the portfolio's LLM discovery summary and points to the detailed source.
+
+- Summary: https://bennyhartnett.com/config/llms.txt
+- Full details: https://bennyhartnett.com/config/llms-full.txt
+- Contact: https://contact.bennyhartnett.com/
+
+For complete metadata and structured content, use:
+https://bennyhartnett.com/config/llms-full.txt

--- a/robots.txt
+++ b/robots.txt
@@ -18,10 +18,15 @@ Disallow: /download
 
 # AI/LLM Crawlers - Welcome!
 # For AI assistants and LLM crawlers, see our dedicated files:
-# https://bennyhartnett.com/config/llms.txt (summary)
-# https://bennyhartnett.com/config/llms-full.txt (detailed)
+# https://bennyhartnett.com/llms.txt (summary entrypoint)
+# https://bennyhartnett.com/llms-full.txt (detailed entrypoint)
+# https://bennyhartnett.com/config/llms.txt (summary source)
+# https://bennyhartnett.com/config/llms-full.txt (detailed source)
 
 User-agent: GPTBot
+Allow: /
+
+User-agent: OAI-SearchBot
 Allow: /
 
 User-agent: ChatGPT-User

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -72,6 +72,18 @@
   </url>
   <!-- LLM-specific content files (served from main domain) -->
   <url>
+    <loc>https://bennyhartnett.com/llms.txt</loc>
+    <lastmod>2026-04-22</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
+    <loc>https://bennyhartnett.com/llms-full.txt</loc>
+    <lastmod>2026-04-22</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
     <loc>https://bennyhartnett.com/config/llms.txt</loc>
     <lastmod>2026-02-23</lastmod>
     <changefreq>weekly</changefreq>


### PR DESCRIPTION
### Motivation
- Align site with common LLM/agent discovery conventions by providing root-path `llms` entrypoints that agents often expect.
- Make ChatGPT Search (OAI-SearchBot) discoverability explicit by allowlisting its crawler in `robots.txt` so public content can be surfaced and cited.
- Reinforce discovery through standard crawl pathways by adding the new root `llms` files to the sitemap. 

### Description
- Added canonical root-level `llms.txt` and `llms-full.txt` that point to the detailed sources under `config/` to provide stable agent entrypoints. 
- Updated `robots.txt` to advertise both root and `config/` `llms` locations and explicitly `Allow` `OAI-SearchBot` in addition to existing AI crawler directives. 
- Updated `sitemap.xml` to include `https://bennyhartnett.com/llms.txt` and `https://bennyhartnett.com/llms-full.txt` so crawlers discover the new entrypoints. 

### Testing
- Ran the unit test suite with `npm test`. 
- Test run: most tests passed; the suite reported one failing test in `sw.test.js` (`deletes old versioned caches on activate and claims clients`) which is a pre-existing service-worker cache-version assertion and is unrelated to these content/discovery changes. 
- No other automated tests failed after the edits to `robots.txt`, `sitemap.xml`, and the two new `llms` files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e865e29ee0832daf8c4fee3919542c)