### PR TITLE
Update Privacy Policy content and bump service worker cache to v139

### DIFF
--- a/pages/privacy.html
+++ b/pages/privacy.html
@@ -5,6 +5,7 @@
     color: white;
     padding: 1rem;
   }
+
   a {
     color: white;
     text-decoration: none;
@@ -14,379 +15,389 @@
   a:hover {
     color: var(--wave-color);
   }
+
   /* Dark mode scrollbar */
   ::-webkit-scrollbar {
     width: 12px;
   }
+
   ::-webkit-scrollbar-track {
     background: #111;
   }
+
   ::-webkit-scrollbar-thumb {
     background: #444;
     border-radius: 6px;
   }
+
   ::-webkit-scrollbar-thumb:hover {
     background: #555;
   }
+
   * {
     scrollbar-width: thin;
     scrollbar-color: #444 #111;
   }
 </style>
-  <h1>Privacy Policy &amp; Terms of Use</h1>
-  <p>Last updated: <span id="policy-year"></span></p>
 
-  <p>
-    This Privacy Policy and Terms of Use ("Policy") governs your access to and
-    use of <strong>bennyhartnett.com</strong> and all of its subdomains
-    (collectively, the "Site"). By accessing, browsing, or using the Site in any
-    manner, you acknowledge that you have read, understood, and agree to be bound
-    by this Policy in its entirety. If you do not agree to all terms in this
-    Policy, you must immediately cease use of the Site.
-  </p>
+<h1>Privacy Policy and Terms of Use</h1>
+<p><strong>BennyHartnett.com and its subdomains</strong></p>
+<p>Last Updated: April 22, 2026</p>
 
-  <p>
-    The Site is owned and operated by Benny Hartnett ("Owner," "we," "us," or
-    "our"). References to "you" or "your" refer to any individual or entity
-    accessing the Site.
-  </p>
+<p>
+  This Privacy Policy and Terms of Use (&quot;Policy&quot;) governs your access to and use of
+  bennyhartnett.com and all related subdomains, pages, features, forms, content, tools, and
+  services (collectively, the &quot;Site&quot;). By accessing, browsing, using, interacting with, or
+  submitting information through the Site, you acknowledge that you have read, understood, and
+  agreed to be bound by this Policy. If you do not agree, you must not access or use the Site.
+</p>
 
-  <h2>1. Information We Collect</h2>
-  <p>We collect and may collect the following categories of information:</p>
-  <ul>
-    <li>
-      <strong>Contact form submissions:</strong> When you use the contact form on
-      the Site, your name, email address, and message content are transmitted to
-      and processed by a third-party form service (Formly.email). We have no
-      control over how that third party stores, processes, or retains your data
-      beyond what is described in their own privacy policy.
-    </li>
-    <li>
-      <strong>Chat interactions:</strong> If you use the AI chat feature on the
-      Site, your messages and conversation history are transmitted to third-party
-      services (including Google Apps Script and AI model providers) for
-      processing. Chat data may be logged, stored, or used by these third parties
-      in accordance with their own policies. Do not submit sensitive, personal,
-      or confidential information through the chat feature.
-    </li>
-    <li>
-      <strong>Analytics data:</strong> We use Google Analytics to collect
-      information about your usage of the Site, including but not limited to page
-      views, navigation paths, outbound link clicks, file downloads, form
-      submission events, browser type, device information, operating system,
-      referring URLs, session duration, and approximate geographic location. This
-      data is processed by Google in accordance with Google's privacy policy.
-    </li>
-    <li>
-      <strong>Server and CDN logs:</strong> Our hosting infrastructure (including
-      GitHub Pages and Cloudflare) may automatically log connection data such as
-      IP addresses, request timestamps, browser user-agent strings, and requested
-      URLs. These logs are controlled by the respective infrastructure providers
-      and are subject to their privacy policies.
-    </li>
-    <li>
-      <strong>Local browser storage:</strong> The Site uses browser localStorage
-      and sessionStorage to store user preferences (such as dark mode settings)
-      and temporary routing data. This data remains on your device and is not
-      transmitted to us.
-    </li>
-    <li>
-      <strong>Service worker cache:</strong> The Site uses a service worker that
-      caches assets on your device for performance and offline access. This cache
-      is stored locally on your device.
-    </li>
-    <li>
-      <strong>Email communications:</strong> If you contact us at
-      <a href="#" class="copy-email protected-email">[click to reveal email]</a>,
-      we retain the content of your communication and any information you
-      voluntarily provide.
-    </li>
-    <li>
-      <strong>Any other data:</strong> Any additional information that you
-      voluntarily submit through the Site, or that is automatically collected by
-      cookies, tracking pixels, scripts, or similar technologies employed by us
-      or our third-party service providers.
-    </li>
-  </ul>
+<p>
+  The Site is owned and operated by Benny Hartnett (&quot;Owner,&quot; &quot;we,&quot; &quot;us,&quot; or &quot;our&quot;).
+  References to &quot;you&quot; and &quot;your&quot; mean any person or entity accessing or using the Site.
+</p>
 
-  <h2>2. Third-Party Services</h2>
-  <p>
-    The Site relies on and integrates with third-party services, including but
-    not limited to:
-  </p>
-  <ul>
-    <li>Google Analytics (analytics and tracking)</li>
-    <li>Google Fonts (font delivery)</li>
-    <li>Google Apps Script (chat backend processing)</li>
-    <li>Formly.email (contact form processing)</li>
-    <li>Cloudflare (DNS, CDN, and edge routing)</li>
-    <li>GitHub Pages (hosting)</li>
-    <li>jsDelivr, unpkg, cdnjs (JavaScript library CDNs)</li>
-    <li>Font Awesome (icon delivery)</li>
-    <li>AI/LLM model providers (chat functionality)</li>
-  </ul>
-  <p>
-    Each of these services may independently collect data about you, including
-    your IP address, browser information, and usage patterns. We have no control
-    over and assume no responsibility for the privacy practices, data collection,
-    data retention, or security measures of any third-party service. Your use of
-    the Site constitutes your acknowledgment and acceptance of these third-party
-    data practices. You are encouraged to review the privacy policies of each
-    third-party provider independently.
-  </p>
+<h2>1. Eligibility and Limited License</h2>
+<p>
+  You represent that you are legally capable of entering into this Policy and of complying with all
+  applicable laws. We grant you a limited, revocable, non-exclusive, non-transferable,
+  non-sublicensable license to access and use the Site solely for personal, informational, and
+  lawful purposes. No ownership or other rights are transferred to you.
+</p>
 
-  <h2>3. Cookies and Tracking Technologies</h2>
-  <p>
-    We and our third-party service providers use cookies, web beacons, analytics
-    scripts, tracking pixels, local storage, and other similar technologies to
-    collect information about your interactions with the Site. By continuing to
-    use the Site, you consent to the use of these technologies. If you do not
-    consent, you must discontinue use of the Site immediately.
-  </p>
+<h2>2. Changes to the Site and This Policy</h2>
+<p>
+  We may modify, suspend, restrict, discontinue, or replace any part of the Site or this Policy at
+  any time, with or without notice, to the fullest extent permitted by law. Unless we expressly
+  state otherwise, changes apply prospectively from the date they are posted. Your continued use of
+  the Site after any posted change constitutes your acceptance of the revised Policy.
+</p>
 
-  <h2>4. How We Use Your Data</h2>
-  <p>
-    We reserve the right to use any information collected through the Site for
-    any lawful purpose, including but not limited to:
-  </p>
-  <ul>
-    <li>Responding to your inquiries and communications</li>
-    <li>Analyzing Site traffic and usage patterns</li>
-    <li>Improving, maintaining, and optimizing the Site</li>
-    <li>Marketing, advertising, and promotional purposes</li>
-    <li>Enforcing this Policy and any applicable terms</li>
-    <li>Complying with legal obligations</li>
-    <li>Any other purpose at our sole discretion</li>
-  </ul>
+<h2>3. Information We Collect</h2>
+<p>
+  Depending on how you use the Site, we or our service providers may collect and process the
+  following categories of information:
+</p>
+<ul>
+  <li>
+    Information you voluntarily submit, such as your name, email address, message content,
+    prompts, attachments, feedback, or other information you choose to provide through contact
+    forms, chat tools, email, or similar features.
+  </li>
+  <li>
+    Usage and device information, such as page views, navigation paths, referring URLs,
+    approximate location, browser type, device type, operating system, session data, interaction
+    events, and diagnostics.
+  </li>
+  <li>
+    Technical and network information, such as IP address, timestamps, request metadata,
+    user-agent strings, error logs, security signals, and other infrastructure or CDN logs.
+  </li>
+  <li>
+    Locally stored information, such as preferences, cached content, routing data, or settings
+    stored through cookies, local storage, session storage, or service workers on your device.
+  </li>
+  <li>
+    Information generated through your interactions with AI-enabled or automated features,
+    including prompts, responses, conversation history, metadata, and operational logs maintained
+    by us or our third-party providers.
+  </li>
+  <li>
+    Any other information that is automatically collected by analytics, cookies, pixels, scripts,
+    SDKs, or similar technologies used by us or by service providers supporting the Site.
+  </li>
+</ul>
 
-  <h2>5. Data Sharing and Disclosure</h2>
-  <p>
-    We may share, sell, transfer, or otherwise disclose personal or aggregated
-    data to third parties for any lawful purpose, including but not limited to
-    analytics providers, marketing partners, service providers, business
-    affiliates, or as required by law. We may also disclose information if we
-    believe in good faith that such disclosure is necessary to: (a) comply with
-    applicable law, regulation, or legal process; (b) protect our rights,
-    property, or safety, or the rights, property, or safety of others; or (c)
-    detect, prevent, or address fraud, security, or technical issues.
-  </p>
+<h2>4. Sources of Information</h2>
+<p>
+  We may collect information directly from you, automatically from your device or browser, from
+  third-party services and infrastructure providers, from analytics and anti-abuse tools, and from
+  publicly available or lawfully obtained sources.
+</p>
 
-  <h2>6. Data Retention</h2>
-  <p>
-    We retain data for as long as we deem necessary or useful, or as required by
-    law. Third-party service providers retain data according to their own
-    policies, over which we have no control. We are under no obligation to delete
-    data unless required by applicable law.
-  </p>
+<h2>5. How We Use Information</h2>
+<p>
+  To the fullest extent permitted by law, we may use information we collect or receive for the
+  following purposes:
+</p>
+<ul>
+  <li>operating, hosting, maintaining, debugging, securing, monitoring, and improving the Site;</li>
+  <li>responding to inquiries, messages, requests, and support communications;</li>
+  <li>
+    analyzing usage trends, measuring performance, preventing abuse, and detecting fraud, spam, or
+    misuse;
+  </li>
+  <li>
+    developing, training, evaluating, or improving features, workflows, automations,
+    AI-assisted functionality, and related services, except as otherwise prohibited by applicable
+    law or by express written agreement;
+  </li>
+  <li>
+    enforcing this Policy, protecting rights and property, and investigating suspected misconduct
+    or violations;
+  </li>
+  <li>
+    complying with legal obligations, requests from regulators or law enforcement, court orders,
+    or lawful process; and
+  </li>
+  <li>
+    facilitating corporate transactions, restructuring, diligence, financing, sale, merger,
+    acquisition, or transfer of assets or operations.
+  </li>
+</ul>
 
-  <h2>7. Data Security</h2>
-  <p>
-    We implement reasonable administrative and technical safeguards to protect
-    information. However, no method of electronic transmission or storage is
-    completely secure. <strong>We do not warrant or guarantee the absolute
-    security of any data transmitted to or from the Site.</strong> You transmit
-    data at your own risk. We shall not be liable for any unauthorized access to,
-    or breach of, any data or information.
-  </p>
+<h2>6. Disclosure of Information</h2>
+<p>
+  We may disclose information, to the fullest extent permitted by law, to hosting providers,
+  infrastructure providers, analytics providers, cloud vendors, CDN providers, communications
+  tools, form processors, payment or identity vendors if used, AI or automation providers,
+  professional advisors, insurers, affiliates, contractors, acquirers, successors, counterparties
+  in a transaction, law enforcement, regulators, courts, or other parties where reasonably
+  necessary to operate, secure, improve, enforce, defend, transfer, or wind down the Site. We may
+  also disclose information in aggregated or de-identified form where permitted by law. We do not
+  guarantee that any third party will maintain particular privacy, security, or retention
+  practices, and your use of the Site acknowledges those independent third-party practices.
+</p>
 
-  <h2>8. Children's Privacy</h2>
-  <p>
-    The Site is not intended for use by individuals under the age of 13. We do
-    not knowingly collect personal information from children under 13. If you
-    believe a child under 13 has provided personal information through the Site,
-    please contact us and we will take steps to delete such information.
-  </p>
+<h2>7. Cookies, Analytics, and Similar Technologies</h2>
+<p>
+  The Site may use cookies, pixels, local storage, session storage, caching technologies, analytics
+  tools, and similar technologies to remember preferences, measure traffic, enhance functionality,
+  improve security, and support Site operations. You may be able to manage certain technologies
+  through your browser or device settings, but disabling them may impair some functionality. Where
+  applicable law requires consent for particular technologies, such consent may be requested through
+  the Site or through your browser or device controls.
+</p>
 
-  <h2>9. International Data Transfers</h2>
-  <p>
-    The Site is hosted in the United States and may utilize infrastructure and
-    services located in various countries worldwide. By using the Site, you
-    consent to the transfer of your information to the United States and other
-    jurisdictions that may not provide the same level of data protection as your
-    home jurisdiction. You waive any claims arising from the transfer, storage,
-    or processing of your data in any jurisdiction.
-  </p>
+<h2>8. AI Features, Tools, and User Submissions</h2>
+<p>
+  Any forms, prompts, messages, feedback, ideas, suggestions, text, files, or other materials that
+  you submit through the Site are provided at your own risk. Except to the extent prohibited by
+  applicable law or expressly stated otherwise, such submissions are not confidential, and you
+  grant us and our service providers a worldwide, non-exclusive, royalty-free, transferable,
+  sublicensable license to host, store, reproduce, transmit, analyze, adapt, modify, process,
+  create derivative works from, display, and otherwise use such submissions as reasonably necessary
+  to operate, secure, improve, test, train, evaluate, enforce, and support the Site and related
+  services. Do not submit information that you are not authorized to disclose or that you expect to
+  remain private, privileged, or confidential.
+</p>
 
-  <h2>10. Your Rights and Choices</h2>
-  <p>
-    You may request access to, correction of, or deletion of your personal
-    information by emailing
-    <a href="#" class="copy-email protected-email">[click to reveal email]</a>.
-    We will make reasonable efforts to honor such requests, subject to applicable
-    law and our legitimate business needs. We reserve the right to retain data
-    that we are required or permitted by law to keep, or that is necessary for
-    our legitimate interests.
-  </p>
-  <p>
-    Certain jurisdictions may provide additional rights under applicable data
-    protection laws. To the maximum extent permitted by law, any rights not
-    expressly granted in this Policy are reserved.
-  </p>
+<h2>9. Data Retention</h2>
+<p>
+  We retain information for as long as we reasonably determine is necessary or useful for the
+  purposes described in this Policy, for legitimate business needs, for backup and archival
+  purposes, for dispute resolution, for enforcement of this Policy, or as required or permitted by
+  law. Retention periods may vary by category of information, context, sensitivity, and legal or
+  operational requirements. Third-party providers may retain data according to their own practices
+  and policies.
+</p>
 
-  <h2>11. External Links</h2>
-  <p>
-    The Site contains links to external websites operated by third parties,
-    including but not limited to GitHub, LinkedIn, and Medium. We have no control
-    over, and assume no responsibility for, the content, privacy practices, or
-    policies of any third-party websites. Accessing external links is entirely at
-    your own risk.
-  </p>
+<h2>10. Data Security</h2>
+<p>
+  We may use administrative, technical, and organizational measures that we consider reasonable in
+  light of the nature of the Site and available resources. However, no website, network,
+  transmission method, storage environment, AI system, or third-party service is completely secure,
+  error-free, or immune from unauthorized access, outage, interception, misuse, alteration, or
+  loss. We do not guarantee the security, integrity, confidentiality, or availability of any
+  information, and you assume all risks associated with submitting information to or through the
+  Site.
+</p>
 
-  <h2>12. Disclaimer of Warranties</h2>
-  <p>
-    THE SITE AND ALL CONTENT, MATERIALS, INFORMATION, TOOLS, SOFTWARE, AND
-    SERVICES PROVIDED ON OR THROUGH THE SITE ARE PROVIDED ON AN "AS IS" AND "AS
-    AVAILABLE" BASIS WITHOUT WARRANTIES OF ANY KIND, WHETHER EXPRESS, IMPLIED, OR
-    STATUTORY. TO THE FULLEST EXTENT PERMITTED BY APPLICABLE LAW, THE OWNER
-    DISCLAIMS ALL WARRANTIES, INCLUDING BUT NOT LIMITED TO IMPLIED WARRANTIES OF
-    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, TITLE, NON-INFRINGEMENT,
-    AND ACCURACY. THE OWNER DOES NOT WARRANT THAT THE SITE WILL BE
-    UNINTERRUPTED, ERROR-FREE, SECURE, OR FREE OF VIRUSES OR OTHER HARMFUL
-    COMPONENTS.
-  </p>
-  <p>
-    THE AI CHAT FEATURE AND ANY TOOLS PROVIDED ON THE SITE (INCLUDING THE
-    NUCLEAR CALCULATOR) ARE PROVIDED FOR INFORMATIONAL AND EDUCATIONAL PURPOSES
-    ONLY. OUTPUT FROM AI FEATURES OR CALCULATORS SHOULD NOT BE RELIED UPON FOR
-    ANY CRITICAL, FINANCIAL, LEGAL, MEDICAL, ENGINEERING, OR SAFETY-RELATED
-    DECISION. THE OWNER MAKES NO REPRESENTATIONS REGARDING THE ACCURACY,
-    COMPLETENESS, OR RELIABILITY OF ANY OUTPUT GENERATED BY THESE FEATURES.
-  </p>
+<h2>11. International Transfers</h2>
+<p>
+  The Site may be hosted, operated, supported, or accessed in the United States and other
+  jurisdictions. By using the Site and providing information, you understand that your information
+  may be transferred to, processed in, and stored in countries that may have privacy or
+  data-protection laws different from those in your jurisdiction.
+</p>
 
-  <h2>13. Limitation of Liability</h2>
-  <p>
-    TO THE MAXIMUM EXTENT PERMITTED BY APPLICABLE LAW, IN NO EVENT SHALL THE
-    OWNER, OR ANY OF THE OWNER'S AFFILIATES, AGENTS, LICENSORS, SERVICE
-    PROVIDERS, CONTRACTORS, OR REPRESENTATIVES, BE LIABLE FOR ANY DIRECT,
-    INDIRECT, INCIDENTAL, SPECIAL, CONSEQUENTIAL, EXEMPLARY, OR PUNITIVE
-    DAMAGES, INCLUDING BUT NOT LIMITED TO DAMAGES FOR LOSS OF PROFITS, GOODWILL,
-    DATA, USE, OR OTHER INTANGIBLE LOSSES, ARISING OUT OF OR IN CONNECTION WITH:
-  </p>
-  <ul>
-    <li>Your access to, use of, or inability to use the Site</li>
-    <li>Any content, information, or materials obtained from or through the Site</li>
-    <li>Any conduct or content of any third party on or connected to the Site</li>
-    <li>Unauthorized access to, alteration of, or loss of your data or transmissions</li>
-    <li>Any errors, inaccuracies, or omissions in Site content or tools</li>
-    <li>Any reliance on AI chat output, calculator results, or other generated content</li>
-    <li>Any interaction with third-party services integrated into the Site</li>
-    <li>Any other matter relating to the Site</li>
-  </ul>
-  <p>
-    THIS LIMITATION APPLIES WHETHER THE ALLEGED LIABILITY IS BASED ON CONTRACT,
-    TORT (INCLUDING NEGLIGENCE), STRICT LIABILITY, OR ANY OTHER BASIS, EVEN IF
-    THE OWNER HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES. IN
-    JURISDICTIONS THAT DO NOT ALLOW THE EXCLUSION OR LIMITATION OF CERTAIN
-    DAMAGES, THE OWNER'S LIABILITY SHALL BE LIMITED TO THE MAXIMUM EXTENT
-    PERMITTED BY LAW.
-  </p>
-  <p>
-    IN NO EVENT SHALL THE OWNER'S TOTAL AGGREGATE LIABILITY FOR ALL CLAIMS
-    ARISING OUT OF OR RELATING TO THE SITE OR THIS POLICY EXCEED ONE UNITED
-    STATES DOLLAR (USD $1.00).
-  </p>
+<h2>12. Your Privacy Rights</h2>
+<p>
+  Depending on your jurisdiction, you may have certain rights regarding personal information, which
+  may include rights to request access, correction, deletion, portability, restriction, objection,
+  or opt-out of certain processing or disclosures. Any such rights are subject to applicable law,
+  exceptions, verification procedures, and our ability to authenticate and fulfill the request using
+  commercially reasonable methods. Requests may be submitted to
+  <a href="mailto:me@bennyhartnett.com">me@bennyhartnett.com</a>. We may require information
+  reasonably necessary to verify your request and protect against fraud or misuse.
+</p>
 
-  <h2>14. Indemnification</h2>
-  <p>
-    You agree to indemnify, defend, and hold harmless the Owner and the Owner's
-    affiliates, agents, licensors, service providers, contractors, and
-    representatives from and against any and all claims, liabilities, damages,
-    losses, costs, and expenses (including reasonable attorneys' fees and court
-    costs) arising out of or in any way connected with: (a) your access to or
-    use of the Site; (b) your violation of this Policy; (c) your violation of
-    any applicable law or regulation; or (d) your violation of any rights of a
-    third party. This indemnification obligation shall survive termination of
-    your use of the Site and any changes to this Policy.
-  </p>
+<h2>13. Children's Privacy</h2>
+<p>
+  The Site is not directed to children under 13, and we do not knowingly request or intentionally
+  collect personal information from children under 13 through the Site. If you believe that a child
+  may have provided personal information through the Site, contact us and we may take steps we deem
+  appropriate under applicable law.
+</p>
 
-  <h2>15. Assumption of Risk</h2>
-  <p>
-    You expressly acknowledge and agree that your use of the Site is at your sole
-    risk. You assume all risks associated with using the Site, including but not
-    limited to risks of data breach, malware exposure, inaccurate information,
-    third-party data collection, and any consequences arising from interactions
-    with AI-generated content or third-party services accessible through the
-    Site.
-  </p>
+<h2>14. Third-Party Services and External Links</h2>
+<p>
+  The Site may rely on or link to third-party services, platforms, libraries, fonts, CDNs,
+  analytics providers, repositories, social platforms, embedded content, APIs, infrastructure, or
+  external websites. Those parties may collect data directly from you and are governed by their own
+  terms and policies. We do not control, endorse, monitor, or assume responsibility for any
+  third-party content, availability, performance, conduct, policies, or data practices. To the
+  fullest extent permitted by law, you release and discharge us from claims arising out of or
+  relating to any third-party service, content, act, omission, outage, failure, breach, or policy.
+</p>
 
-  <h2>16. Dispute Resolution and Governing Law</h2>
-  <p>
-    This Policy and any disputes arising from or relating to the Site shall be
-    governed by and construed in accordance with the laws of the United States
-    and the State of Maryland, without regard to conflict of law principles. Any
-    dispute, claim, or controversy arising out of or relating to this Policy or
-    the Site shall be resolved exclusively in the state or federal courts located
-    in Maryland, and you irrevocably consent to the personal jurisdiction and
-    venue of such courts.
-  </p>
-  <p>
-    To the fullest extent permitted by law, you agree that any claim or cause of
-    action arising out of or related to use of the Site or this Policy must be
-    filed within one (1) year after such claim or cause of action arose, or be
-    forever barred.
-  </p>
+<h2>15. Intellectual Property</h2>
+<p>
+  The Site and all content, design, layout, branding, graphics, text, software, code, features,
+  and compilations made available through the Site are owned by us or our licensors and are
+  protected by applicable intellectual-property and unfair-competition laws. Except for the limited
+  license expressly granted above, no right, title, or interest is granted to you. You may not
+  copy, reproduce, distribute, republish, sell, license, scrape, mirror, frame, modify, create
+  derivative works from, reverse engineer, or exploit the Site except as expressly authorized in
+  writing.
+</p>
 
-  <h2>17. Waiver of Class Action</h2>
-  <p>
-    TO THE FULLEST EXTENT PERMITTED BY LAW, YOU AGREE THAT ANY PROCEEDINGS TO
-    RESOLVE DISPUTES WILL BE CONDUCTED SOLELY ON AN INDIVIDUAL BASIS, AND YOU
-    WAIVE YOUR RIGHT TO PARTICIPATE IN A CLASS ACTION, CLASS ARBITRATION, OR ANY
-    OTHER REPRESENTATIVE PROCEEDING. IF THIS WAIVER IS FOUND TO BE
-    UNENFORCEABLE, THEN THE ENTIRETY OF THIS DISPUTE RESOLUTION SECTION SHALL BE
-    NULL AND VOID.
-  </p>
+<h2>16. Prohibited Conduct</h2>
+<p>You agree not to, and not to assist or permit others to:</p>
+<ul>
+  <li>
+    use the Site for any unlawful, fraudulent, infringing, harassing, abusive, defamatory,
+    invasive, or deceptive purpose;
+  </li>
+  <li>
+    submit viruses, malicious code, exploits, prompts intended to bypass safeguards, or other
+    harmful material;
+  </li>
+  <li>
+    scrape, crawl, harvest, mirror, copy, mine, or index the Site or Site outputs using bots,
+    scripts, automation, or similar methods without prior written authorization;
+  </li>
+  <li>
+    interfere with the Site, impair performance, probe or test vulnerabilities, bypass access
+    restrictions, or attempt unauthorized access to systems, accounts, or data;
+  </li>
+  <li>
+    use Site content, outputs, or data to build, benchmark, train, or improve competing products,
+    models, datasets, or services without express written permission;
+  </li>
+  <li>
+    submit confidential, proprietary, personal, regulated, or sensitive information unless you are
+    fully authorized to do so and accept all related risks;
+  </li>
+  <li>
+    use the Site or any outputs for legal, medical, financial, engineering, compliance, emergency,
+    or other high-risk decisions; or
+  </li>
+  <li>misrepresent your identity, affiliation, authority, or rights in connection with the Site.</li>
+</ul>
 
-  <h2>18. Severability</h2>
-  <p>
-    If any provision of this Policy is held to be invalid, illegal, or
-    unenforceable by a court of competent jurisdiction, such invalidity,
-    illegality, or unenforceability shall not affect any other provision of this
-    Policy. The remaining provisions shall continue in full force and effect, and
-    the invalid provision shall be modified to the minimum extent necessary to
-    make it valid, legal, and enforceable while preserving its original intent.
-  </p>
+<h2>17. No Duty to Monitor; Right to Restrict or Remove</h2>
+<p>
+  We reserve the right, but not the obligation, to monitor, review, screen, log, investigate,
+  remove, disable, restrict, suspend, block, preserve, or disclose any content, submission, access,
+  or activity on or relating to the Site at any time, with or without notice, for any reason or no
+  reason, and without liability.
+</p>
 
-  <h2>19. Entire Agreement</h2>
-  <p>
-    This Policy constitutes the entire agreement between you and the Owner with
-    respect to your use of the Site and supersedes all prior or contemporaneous
-    communications, representations, or agreements, whether oral or written,
-    regarding the subject matter herein.
-  </p>
+<h2>18. AI, Calculators, and Informational Content — No Reliance</h2>
+<p>
+  The Site may include AI-assisted features, automated outputs, calculators, generated content,
+  blog content, code, examples, technical commentary, or other informational material. All such
+  materials are provided solely for general informational, educational, or experimental purposes.
+  They may be inaccurate, incomplete, biased, outdated, offensive, unavailable, or unsuitable for
+  your circumstances. You are solely responsible for independently evaluating, verifying, and
+  assuming all risks arising from any use of such materials. The Site is not intended for and must
+  not be used for legal, medical, financial, engineering, employment, compliance, safety-critical,
+  or emergency purposes.
+</p>
 
-  <h2>20. Policy Updates</h2>
-  <p>
-    We reserve the right to modify this Policy at any time, at our sole
-    discretion, without prior notice. Changes are effective immediately upon
-    posting to the Site. Your continued use of the Site after any changes
-    constitutes your acceptance of the revised Policy. It is your responsibility
-    to review this Policy periodically for updates.
-  </p>
+<h2>19. Disclaimer of Warranties</h2>
+<p>
+  TO THE FULLEST EXTENT PERMITTED BY APPLICABLE LAW, THE SITE AND ALL CONTENT, FEATURES, OUTPUTS,
+  TOOLS, SOFTWARE, MATERIALS, COMMUNICATIONS, AND SERVICES MADE AVAILABLE THROUGH THE SITE ARE
+  PROVIDED &quot;AS IS,&quot; &quot;AS AVAILABLE,&quot; &quot;WITH ALL FAULTS,&quot; AND WITHOUT WARRANTIES OR REPRESENTATIONS
+  OF ANY KIND, WHETHER EXPRESS, IMPLIED, STATUTORY, OR OTHERWISE. WE DISCLAIM, TO THE FULLEST
+  EXTENT PERMITTED BY LAW, ALL WARRANTIES INCLUDING IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS
+  FOR A PARTICULAR PURPOSE, TITLE, NON-INFRINGEMENT, QUIET ENJOYMENT, SYSTEM INTEGRATION, DATA
+  ACCURACY, AND FREEDOM FROM INTERRUPTION, ERROR, VIRUSES, HARMFUL COMPONENTS, OR SECURITY
+  FAILURES. WE DO NOT WARRANT THAT THE SITE WILL MEET YOUR REQUIREMENTS OR EXPECTATIONS OR THAT ANY
+  DEFECTS WILL BE CORRECTED.
+</p>
 
-  <h2>21. No Waiver</h2>
-  <p>
-    The failure of the Owner to enforce any provision of this Policy shall not
-    constitute a waiver of that provision or any other provision. Any waiver of
-    any provision of this Policy will be effective only if in writing and signed
-    by the Owner.
-  </p>
+<h2>20. Limitation of Liability</h2>
+<p>
+  TO THE FULLEST EXTENT PERMITTED BY APPLICABLE LAW, IN NO EVENT SHALL THE OWNER OR ANY OF THE
+  OWNER'S AFFILIATES, LICENSORS, SERVICE PROVIDERS, VENDORS, CONTRACTORS, ADVISORS, AGENTS, OR
+  REPRESENTATIVES BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, CONSEQUENTIAL,
+  EXEMPLARY, PUNITIVE, OR OTHER DAMAGES, OR FOR ANY LOSS OF PROFITS, REVENUE, BUSINESS,
+  OPPORTUNITY, DATA, USE, GOODWILL, SAVINGS, OR OTHER INTANGIBLE LOSSES, ARISING OUT OF OR
+  RELATING TO THE SITE, THIS POLICY, THIRD-PARTY SERVICES, SITE CONTENT, AI OUTPUTS, USER
+  SUBMISSIONS, SECURITY INCIDENTS, DOWN TIME, ERRORS, OR YOUR ACCESS TO, USE OF, INABILITY TO USE,
+  OR RELIANCE ON THE SITE, WHETHER BASED IN CONTRACT, TORT, NEGLIGENCE, STRICT LIABILITY, STATUTE,
+  OR ANY OTHER THEORY, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGES. TO THE FULLEST EXTENT
+  PERMITTED BY LAW, OUR TOTAL AGGREGATE LIABILITY FOR ALL CLAIMS ARISING OUT OF OR RELATING TO THE
+  SITE OR THIS POLICY SHALL NOT EXCEED THE GREATER OF ONE UNITED STATES DOLLAR (US $1.00) OR THE
+  AMOUNT, IF ANY, YOU PAID US DIRECTLY TO USE THE SITE IN THE TWELVE (12) MONTHS PRECEDING THE
+  EVENT GIVING RISE TO THE CLAIM.
+</p>
 
-  <h2>22. Contact</h2>
-  <p>
-    For questions about this Policy, contact us at
-    <a href="#" class="copy-email protected-email">[click to reveal email]</a>.
-  </p>
+<h2>21. Indemnification</h2>
+<p>
+  You agree to defend, indemnify, and hold harmless the Owner and the Owner's affiliates,
+  licensors, service providers, contractors, vendors, advisors, agents, and representatives from
+  and against any and all claims, demands, actions, proceedings, liabilities, damages, judgments,
+  awards, losses, costs, and expenses, including reasonable attorneys' fees and costs, arising out
+  of or relating to your access to or use of the Site, your submissions, your breach of this
+  Policy, your violation of law, or your infringement or violation of any rights of another person
+  or entity.
+</p>
 
-  <a href="/">Back to Home</a>
+<h2>22. Termination</h2>
+<p>
+  We may terminate or suspend your access to the Site, in whole or in part, at any time, with or
+  without notice, for any reason or no reason, and without liability. Upon termination, the rights
+  and licenses granted to you will immediately cease, but all provisions that by their nature should
+  survive shall survive, including provisions concerning ownership, submissions, disclaimers,
+  liability limitations, releases, indemnification, dispute resolution, and interpretation.
+</p>
 
-  <script>
-    document.getElementById('policy-year').textContent = new Date().getFullYear();
-    // Populate protected email fields at runtime to prevent scraping
-    document.querySelectorAll('.protected-email').forEach(function(el) {
-      if (window.getProtectedEmail) {
-        var email = window.getProtectedEmail();
-        el.textContent = email;
-        el.dataset.email = email;
-      }
-    });
-  </script>
+<h2>23. Dispute Resolution, Governing Law, and Venue</h2>
+<p>
+  To the fullest extent permitted by law, this Policy and any dispute, claim, or controversy
+  arising out of or relating to the Site or this Policy shall be governed by the laws of the State
+  of Maryland and the United States, without regard to conflict-of-law principles. Any such dispute
+  shall be brought exclusively in the state or federal courts located in Maryland, and you
+  irrevocably consent to the personal jurisdiction and venue of those courts. You waive any
+  objection based on forum non conveniens or any similar doctrine. You also waive, to the fullest
+  extent permitted by law, any right to a jury trial in connection with any dispute arising out of
+  or relating to the Site or this Policy.
+</p>
+
+<h2>24. Class Action Waiver and Time Limitation</h2>
+<p>
+  TO THE FULLEST EXTENT PERMITTED BY LAW, YOU AND THE OWNER AGREE THAT ANY CLAIM OR PROCEEDING
+  SHALL BE BROUGHT ONLY IN AN INDIVIDUAL CAPACITY AND NOT AS A PLAINTIFF, CLASS MEMBER, OR
+  REPRESENTATIVE IN ANY PURPORTED CLASS, CONSOLIDATED, MASS, COLLECTIVE, OR REPRESENTATIVE ACTION
+  OR PROCEEDING. TO THE FULLEST EXTENT PERMITTED BY LAW, ANY CLAIM ARISING OUT OF OR RELATING TO
+  THE SITE OR THIS POLICY MUST BE FILED WITHIN ONE (1) YEAR AFTER THE CLAIM AROSE OR IT IS FOREVER
+  BARRED.
+</p>
+
+<h2>25. Severability; No Waiver; Entire Agreement; Assignment</h2>
+<p>
+  If any provision of this Policy is held to be invalid, illegal, or unenforceable, that provision
+  shall be enforced to the maximum extent permitted and the remaining provisions shall remain in
+  full force and effect. No waiver of any provision shall be effective unless in writing and signed
+  by the Owner. This Policy constitutes the entire agreement between you and the Owner regarding the
+  Site and supersedes prior or contemporaneous understandings relating to the Site. We may assign,
+  transfer, or delegate this Policy and any rights or obligations under it, in whole or in part,
+  without restriction. You may not assign this Policy without our prior written consent.
+</p>
+
+<h2>26. Contact</h2>
+<p>
+  For questions or requests relating to this Policy, contact:
+  <a href="mailto:me@bennyhartnett.com">me@bennyhartnett.com</a>
+</p>
+
+<p>
+  This document is intended for publication on the Site as the governing Privacy Policy and Terms of
+  Use.
+</p>
+
+<a href="/">Back to Home</a>

--- a/sw.js
+++ b/sw.js
@@ -1,6 +1,6 @@
 // Service Worker for SWU Calculator PWA
 // Version must be updated when deploying new code to bust cache
-const CACHE_VERSION = 'v138';
+const CACHE_VERSION = 'v139';
 const CACHE_NAME = `swu-calculator-${CACHE_VERSION}`;
 
 // Files to cache for offline use

--- a/sw.test.js
+++ b/sw.test.js
@@ -49,7 +49,7 @@ describe('sw.js service worker', () => {
 
     globalThis.caches = {
       open: vi.fn(() => Promise.resolve(activeCache)),
-      keys: vi.fn(() => Promise.resolve(['swu-calculator-v136', 'swu-calculator-v137'])),
+      keys: vi.fn(() => Promise.resolve(['swu-calculator-v137', 'swu-calculator-v139'])),
       delete: vi.fn(() => Promise.resolve(true)),
       match: vi.fn((request) => Promise.resolve(cacheStore.get(String(request.url ?? request)) ?? undefined)),
       __cacheStore: cacheStore,
@@ -83,8 +83,8 @@ describe('sw.js service worker', () => {
     handlers.activate(event);
     await Promise.all(event.waits);
 
-    expect(caches.delete).toHaveBeenCalledWith('swu-calculator-v136');
-    expect(caches.delete).not.toHaveBeenCalledWith('swu-calculator-v137');
+    expect(caches.delete).toHaveBeenCalledWith('swu-calculator-v137');
+    expect(caches.delete).not.toHaveBeenCalledWith('swu-calculator-v139');
     expect(self.clients.claim).toHaveBeenCalledTimes(1);
   });
 


### PR DESCRIPTION
### Motivation
- Publish the updated Privacy Policy and Terms of Use text with the new effective date so site visitors see the current policy.
- Ensure clients receive the updated policy by invalidating the service worker cache when deploying the change.
- Keep automated tests in sync with the service worker cache version to avoid CI failures.

### Description
- Replaced the privacy page at `pages/privacy.html` with the provided full Privacy Policy and Terms of Use text (Last Updated: April 22, 2026) and updated contact links to use `mailto:me@bennyhartnett.com`.
- Bumped the service worker `CACHE_VERSION` from `v138` to `v139` in `sw.js` to force cache refresh for clients.
- Updated `sw.test.js` expectations to match the new cache version so service worker unit tests reflect the change.

### Testing
- Ran the test suite with `npm test` (Vitest) and addressed an initial failure in `sw.test.js` caused by the cache-version mismatch. 
- After updating the test expectations, re-ran `npm test` and confirmed all tests passed: 98 tests across the suite (including `sw.test.js`) succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e86636e444832db01a173a86473af5)