### PR TITLE
Improve SEO crawlability and snippet directives

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,7 +39,8 @@
   <link rel="icon" type="image/svg+xml" sizes="32x32" href="/favicon.svg" />
   <link rel="icon" type="image/svg+xml" sizes="16x16" href="/favicon.svg" />
   <link rel="shortcut icon" href="/favicon.svg" />
-  <meta name="robots" content="index,follow" />
+  <meta name="robots" content="index,follow,max-image-preview:large,max-snippet:-1,max-video-preview:-1" />
+  <meta name="googlebot" content="index,follow,max-image-preview:large,max-snippet:-1,max-video-preview:-1" />
   <meta name="theme-color" content="#0D6EFD" />
   <meta name="mobile-web-app-capable" content="yes" />
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
@@ -480,6 +481,20 @@
   </script>
 </head>
 <body>
+  <noscript>
+    <nav aria-label="Noscript page navigation">
+      <ul>
+        <li><a href="https://bennyhartnett.com/">Home</a></li>
+        <li><a href="https://projects.bennyhartnett.com/">Projects</a></li>
+        <li><a href="https://contact.bennyhartnett.com/">Contact</a></li>
+        <li><a href="https://chat.bennyhartnett.com/">Chat</a></li>
+        <li><a href="https://nuclear.bennyhartnett.com/">Nuclear</a></li>
+        <li><a href="https://xn--rsum-bpad.bennyhartnett.com/">Résumé</a></li>
+        <li><a href="https://privacy.bennyhartnett.com/">Privacy</a></li>
+      </ul>
+    </nav>
+  </noscript>
+
   <svg class="fx-defs" aria-hidden="true" focusable="false" width="0" height="0">
     <defs>
       <filter id="home-fx-targeted-filter" x="-20%" y="-20%" width="140%" height="140%" color-interpolation-filters="sRGB">

--- a/sw.js
+++ b/sw.js
@@ -1,6 +1,6 @@
 // Service Worker for SWU Calculator PWA
 // Version must be updated when deploying new code to bust cache
-const CACHE_VERSION = 'v139';
+const CACHE_VERSION = 'v140';
 const CACHE_NAME = `swu-calculator-${CACHE_VERSION}`;
 
 // Files to cache for offline use

--- a/sw.test.js
+++ b/sw.test.js
@@ -49,7 +49,7 @@ describe('sw.js service worker', () => {
 
     globalThis.caches = {
       open: vi.fn(() => Promise.resolve(activeCache)),
-      keys: vi.fn(() => Promise.resolve(['swu-calculator-v137', 'swu-calculator-v139'])),
+      keys: vi.fn(() => Promise.resolve(['swu-calculator-v137', 'swu-calculator-v140'])),
       delete: vi.fn(() => Promise.resolve(true)),
       match: vi.fn((request) => Promise.resolve(cacheStore.get(String(request.url ?? request)) ?? undefined)),
       __cacheStore: cacheStore,
@@ -84,7 +84,7 @@ describe('sw.js service worker', () => {
     await Promise.all(event.waits);
 
     expect(caches.delete).toHaveBeenCalledWith('swu-calculator-v137');
-    expect(caches.delete).not.toHaveBeenCalledWith('swu-calculator-v139');
+    expect(caches.delete).not.toHaveBeenCalledWith('swu-calculator-v140');
     expect(self.clients.claim).toHaveBeenCalledTimes(1);
   });
 


### PR DESCRIPTION
### Motivation
- Bring site markup in line with modern search/AI preview guidance by explicitly controlling snippet and preview behavior. 
- Improve crawl resilience for the SPA by providing a non-JS link graph so crawlers and users without JavaScript can discover key subdomains. 
- Ensure clients receive updated HTML/metadata by invalidating the service worker cache after these SEO changes.

### Description
- Added richer preview/snippet directives to the document head by updating the `robots` meta and adding a `googlebot` meta with `max-image-preview:large`, `max-snippet:-1`, and `max-video-preview:-1` in `index.html`.
- Added a `<noscript>` navigation block with canonical subdomain links in `index.html` to expose key pages when JavaScript-driven routing is unavailable.
- Bumped the service worker `CACHE_VERSION` from `v139` to `v140` in `sw.js` to force cache invalidation after the markup changes.
- Updated `sw.test.js` expectations to match the new cache version so tests reflect the bumped `CACHE_VERSION`.

### Testing
- Ran the test suite with `npm test` (Vitest), fixed a failing service-worker version expectation, and re-ran the suite.
- Final result: all automated tests passed (`98` tests passing, `0` failures).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8687f997c832da44775099a052de7)