### PR TITLE
Style privacy policy with glassmorphic card and bump SW cache version

### DIFF
--- a/pages/privacy.html
+++ b/pages/privacy.html
@@ -6,6 +6,30 @@
     padding: 1rem;
   }
 
+  .privacy-shell {
+    max-width: 980px;
+    margin: 0 auto;
+  }
+
+  .glass-card {
+    border-radius: 20px;
+    padding: clamp(1.25rem, 2vw, 2rem);
+    background: rgba(12, 18, 31, 0.56);
+    border: 1px solid rgba(255, 255, 255, 0.24);
+    box-shadow: 0 10px 36px rgba(0, 0, 0, 0.35);
+    backdrop-filter: blur(14px) saturate(130%);
+    -webkit-backdrop-filter: blur(14px) saturate(130%);
+  }
+
+  .glass-card h1 {
+    margin-top: 0;
+  }
+
+  .glass-card a:last-child {
+    display: inline-block;
+    margin-top: 0.5rem;
+  }
+
   a {
     color: white;
     text-decoration: none;
@@ -40,6 +64,8 @@
   }
 </style>
 
+<main class="privacy-shell">
+  <article class="glass-card">
 <h1>Privacy Policy and Terms of Use</h1>
 <p><strong>BennyHartnett.com and its subdomains</strong></p>
 <p>Last Updated: April 22, 2026</p>
@@ -401,3 +427,5 @@
 </p>
 
 <a href="/">Back to Home</a>
+  </article>
+</main>

--- a/sw.js
+++ b/sw.js
@@ -1,6 +1,6 @@
 // Service Worker for SWU Calculator PWA
 // Version must be updated when deploying new code to bust cache
-const CACHE_VERSION = 'v139';
+const CACHE_VERSION = 'v140';
 const CACHE_NAME = `swu-calculator-${CACHE_VERSION}`;
 
 // Files to cache for offline use

--- a/sw.test.js
+++ b/sw.test.js
@@ -49,7 +49,7 @@ describe('sw.js service worker', () => {
 
     globalThis.caches = {
       open: vi.fn(() => Promise.resolve(activeCache)),
-      keys: vi.fn(() => Promise.resolve(['swu-calculator-v137', 'swu-calculator-v139'])),
+      keys: vi.fn(() => Promise.resolve(['swu-calculator-v137', 'swu-calculator-v140'])),
       delete: vi.fn(() => Promise.resolve(true)),
       match: vi.fn((request) => Promise.resolve(cacheStore.get(String(request.url ?? request)) ?? undefined)),
       __cacheStore: cacheStore,
@@ -84,7 +84,7 @@ describe('sw.js service worker', () => {
     await Promise.all(event.waits);
 
     expect(caches.delete).toHaveBeenCalledWith('swu-calculator-v137');
-    expect(caches.delete).not.toHaveBeenCalledWith('swu-calculator-v139');
+    expect(caches.delete).not.toHaveBeenCalledWith('swu-calculator-v140');
     expect(self.clients.claim).toHaveBeenCalledTimes(1);
   });
 


### PR DESCRIPTION
### Motivation
- Improve readability and visual hierarchy of the Privacy Policy page by placing content in a focused, elevated container.  
- Ensure clients receive the updated HTML/CSS by invalidating the service worker cache when pages change.  
- Keep service worker tests aligned with the deployed cache version to prevent test breakage.

### Description
- Wrapped the privacy policy content in a centered `main`/`article` container and added `.privacy-shell` and `.glass-card` styles to apply a glassmorphism effect (blurred translucent background, border, rounded corners, shadow).  
- Incremented the service worker cache version from `v139` to `v140` by updating `sw.js` so browsers will refresh cached assets.  
- Updated `sw.test.js` expectations to reference the new cache key (`swu-calculator-v140`) so tests reflect the version bump.

### Testing
- Ran `npm test` (Vitest); an initial run failed due to `sw.test.js` still expecting the old cache key, which was then updated.  
- Re-ran `npm test` and all tests passed: `98` tests across the suite succeeded.  
- The service worker test suite verified install/activate/fetch/message handlers and cache cleanup behavior with the new version key.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e869394f4c832da86102b0097a29d6)