### PR TITLE
Make service worker cache test derive cache version from sw.js

### DIFF
--- a/sw.test.js
+++ b/sw.test.js
@@ -1,6 +1,12 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
 
 let handlers;
+const swSource = readFileSync(resolve(process.cwd(), 'sw.js'), 'utf8');
+const cacheVersionMatch = swSource.match(/const CACHE_VERSION = '([^']+)'/);
+const currentCacheName = cacheVersionMatch ? `swu-calculator-${cacheVersionMatch[1]}` : 'swu-calculator-v140';
+const previousCacheName = currentCacheName.replace(/v(\d+)$/, (_, version) => `v${Number(version) - 1}`);
 
 function makeInstallEvent() {
   const waits = [];
@@ -49,7 +55,7 @@ describe('sw.js service worker', () => {
 
     globalThis.caches = {
       open: vi.fn(() => Promise.resolve(activeCache)),
-      keys: vi.fn(() => Promise.resolve(['swu-calculator-v137', 'swu-calculator-v140'])),
+      keys: vi.fn(() => Promise.resolve([previousCacheName, currentCacheName])),
       delete: vi.fn(() => Promise.resolve(true)),
       match: vi.fn((request) => Promise.resolve(cacheStore.get(String(request.url ?? request)) ?? undefined)),
       __cacheStore: cacheStore,
@@ -83,8 +89,8 @@ describe('sw.js service worker', () => {
     handlers.activate(event);
     await Promise.all(event.waits);
 
-    expect(caches.delete).toHaveBeenCalledWith('swu-calculator-v137');
-    expect(caches.delete).not.toHaveBeenCalledWith('swu-calculator-v140');
+    expect(caches.delete).toHaveBeenCalledWith(previousCacheName);
+    expect(caches.delete).not.toHaveBeenCalledWith(currentCacheName);
     expect(self.clients.claim).toHaveBeenCalledTimes(1);
   });
 


### PR DESCRIPTION
### Motivation

- The sw service worker cache test used hard-coded cache names which go out of sync when `CACHE_VERSION` in `sw.js` is bumped.
- This caused false test failures when the runtime `CACHE_NAME` no longer matched the strings asserted by the test.

### Description

- Updated `sw.test.js` to read `sw.js` at test runtime using `readFileSync` and extract `CACHE_VERSION` via a regex.
- Derived `currentCacheName` and `previousCacheName` from the extracted `CACHE_VERSION` instead of using hard-coded literals.
- Replaced the mocked `caches.keys` fixture and the activate-handler assertions to use the derived cache names so tests track `sw.js` version changes automatically.

### Testing

- Ran `npm test` which executed the Vitest suite and all tests passed (`Test Files 6 passed`, `Tests 98 passed`).
- Running `npm test -- --runInBand` fails because Vitest reports an unknown option `--runInBand`, which is a CLI misuse and not a test failure in the code changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8696aefb8832dab450ea36de3464e)