### PR TITLE
Expand tests: router, service worker, worker routing, and nuclear math edge cases

### DIFF
--- a/js/spa-router.test.js
+++ b/js/spa-router.test.js
@@ -1,4 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { updateMetaTags } from './meta-manager.js';
+import { trackPageView } from './analytics.js';
 
 vi.mock('./meta-manager.js', () => ({
   updateMetaTags: vi.fn(),
@@ -21,7 +23,7 @@ vi.mock('./performance-profile.js', () => ({
   scheduleDeferredTask: vi.fn()
 }));
 
-import { __test__ } from './spa-router.js';
+import { __test__, initRouter, loadContent } from './spa-router.js';
 
 function makeLink({ href, dataHref, external } = {}) {
   return {
@@ -48,9 +50,24 @@ describe('js/spa-router', () => {
 
     globalThis.window = {
       location: {
-        href: 'https://bennyhartnett.com'
+        href: 'https://bennyhartnett.com',
+        origin: 'https://bennyhartnett.com',
+        pathname: '/'
       },
-      open: vi.fn()
+      open: vi.fn(),
+      addEventListener: vi.fn()
+    };
+
+    globalThis.history = {
+      pushState: vi.fn(),
+      replaceState: vi.fn()
+    };
+
+    globalThis.CustomEvent = class {
+      constructor(type, init) {
+        this.type = type;
+        this.detail = init?.detail;
+      }
     };
 
     const storage = new Map();
@@ -58,6 +75,36 @@ describe('js/spa-router', () => {
       getItem: vi.fn((key) => storage.get(key) ?? null),
       setItem: vi.fn((key, value) => storage.set(key, value)),
       removeItem: vi.fn((key) => storage.delete(key))
+    };
+
+    Object.defineProperty(globalThis, 'navigator', {
+      configurable: true,
+      value: {
+        clipboard: {
+          writeText: vi.fn(() => Promise.resolve())
+        }
+      }
+    });
+
+    globalThis.fetch = vi.fn(() => Promise.resolve(new Response('<div>page</div>', { status: 200 })));
+    globalThis.document = {
+      body: {
+        dataset: {},
+        addEventListener: vi.fn(),
+        appendChild: vi.fn(),
+        removeChild: vi.fn()
+      },
+      documentElement: { dataset: {} },
+      dispatchEvent: vi.fn(),
+      querySelectorAll: vi.fn(() => []),
+      querySelector: vi.fn(() => null),
+      getElementById: vi.fn(() => null),
+      createElement: vi.fn(() => ({
+        set type(value) { this._type = value; },
+        set src(value) { this._src = value; },
+        textContent: '',
+        click: vi.fn()
+      }))
     };
   });
 
@@ -96,6 +143,20 @@ describe('js/spa-router', () => {
     globalThis.location.hash = '#tools';
 
     expect(__test__.getInitialPage()).toBe('pages/tools');
+  });
+
+  it('resolves nuclear subdomain to standalone page', () => {
+    globalThis.location.hostname = 'nuclear.bennyhartnett.com';
+
+    expect(__test__.getInitialPage()).toBe('nuclear.html');
+  });
+
+  it('detects subdomain status', () => {
+    globalThis.location.hostname = 'projects.bennyhartnett.com';
+    expect(__test__.isSubdomain()).toBe(true);
+
+    globalThis.location.hostname = 'bennyhartnett.com';
+    expect(__test__.isSubdomain()).toBe(false);
   });
 
   it('opens external links in a new tab', () => {
@@ -172,5 +233,174 @@ describe('js/spa-router', () => {
 
     expect(event.preventDefault).not.toHaveBeenCalled();
     expect(window.location.href).toBe('https://bennyhartnett.com');
+  });
+
+  it('handles .html route links', () => {
+    const link = makeLink({ href: '/contact.html' });
+    const event = {
+      target: { closest: vi.fn((selector) => (selector === 'a' ? link : null)) },
+      preventDefault: vi.fn()
+    };
+
+    __test__.handleLinkClick(event);
+
+    expect(event.preventDefault).toHaveBeenCalled();
+    expect(window.location.href).toBe('https://contact.html.bennyhartnett.com');
+  });
+
+  it('returns early when no anchor is found', () => {
+    const event = {
+      target: { closest: vi.fn(() => null) },
+      preventDefault: vi.fn()
+    };
+
+    __test__.handleLinkClick(event);
+
+    expect(event.preventDefault).not.toHaveBeenCalled();
+  });
+
+  it('copies email for copy-email links', async () => {
+    const emailLink = { dataset: { email: 'hello@example.com' } };
+    const event = {
+      target: {
+        closest: vi.fn((selector) => (selector === '.copy-email' ? emailLink : null))
+      },
+      preventDefault: vi.fn()
+    };
+
+    __test__.handleLinkClick(event);
+    await Promise.resolve();
+
+    expect(event.preventDefault).toHaveBeenCalled();
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith('hello@example.com');
+  });
+
+  it('handles secure resume download action', () => {
+    const createdLink = { click: vi.fn() };
+    document.createElement.mockReturnValue(createdLink);
+
+    const event = {
+      target: {
+        closest: vi.fn((selector) => (selector === '[data-action="download-resume"]' ? {} : null))
+      },
+      preventDefault: vi.fn()
+    };
+
+    __test__.handleLinkClick(event);
+
+    expect(event.preventDefault).toHaveBeenCalled();
+    expect(createdLink.href).toBe('/assets/d/r-8f3a2c9e7b1d.pdf');
+    expect(createdLink.download).toBe('resume_benny_hartnett.pdf');
+    expect(createdLink.click).toHaveBeenCalled();
+    expect(document.body.appendChild).toHaveBeenCalledWith(createdLink);
+    expect(document.body.removeChild).toHaveBeenCalledWith(createdLink);
+  });
+
+  it('initializes router and wires base navigation handlers', () => {
+    const classSet = new Set();
+    const container = {
+      classList: {
+        add: vi.fn((name) => classSet.add(name)),
+        remove: vi.fn((name) => classSet.delete(name))
+      },
+      querySelector: vi.fn(() => null),
+      querySelectorAll: vi.fn(() => []),
+      innerHTML: ''
+    };
+    const canonicalTag = { setAttribute: vi.fn() };
+    const ogUrlTag = { setAttribute: vi.fn() };
+    const title = { addEventListener: vi.fn() };
+
+    document.querySelector = vi.fn((selector) => {
+      if (selector === '#main-content') return container;
+      if (selector === 'nav .title') return title;
+      return null;
+    });
+    document.getElementById = vi.fn((id) => {
+      if (id === 'canonical-link') return canonicalTag;
+      if (id === 'og-url') return ogUrlTag;
+      return null;
+    });
+
+    initRouter();
+
+    expect(document.body.addEventListener).toHaveBeenCalledWith('click', expect.any(Function));
+    expect(window.addEventListener).toHaveBeenCalledWith('popstate', expect.any(Function));
+    expect(history.replaceState).toHaveBeenCalled();
+    expect(canonicalTag.setAttribute).toHaveBeenCalledWith('href', 'https://bennyhartnett.com/');
+    expect(ogUrlTag.setAttribute).toHaveBeenCalledWith('content', 'https://bennyhartnett.com/');
+  });
+
+  it('loads content and updates meta, analytics, and history', async () => {
+    vi.useFakeTimers();
+
+    const classSet = new Set();
+    const scriptNode = { type: '', src: '', textContent: 'console.log("x")', replaceWith: vi.fn() };
+    const container = {
+      classList: {
+        add: vi.fn((name) => classSet.add(name)),
+        remove: vi.fn((name) => classSet.delete(name))
+      },
+      querySelector: vi.fn(() => null),
+      querySelectorAll: vi.fn((selector) => (selector === 'script' ? [scriptNode] : [])),
+      innerHTML: '',
+      get offsetHeight() { return 0; }
+    };
+    const title = { addEventListener: vi.fn() };
+
+    document.querySelector = vi.fn((selector) => {
+      if (selector === '#main-content') return container;
+      if (selector === 'nav .title') return title;
+      return null;
+    });
+    initRouter();
+
+    fetch.mockResolvedValueOnce(new Response('<section>projects</section>', { status: 200 }));
+    loadContent('pages/projects.html', true, true);
+    await vi.runAllTimersAsync();
+
+    expect(updateMetaTags).toHaveBeenCalled();
+    expect(trackPageView).toHaveBeenCalledWith(
+      'pages/projects.html',
+      'Home',
+      'https://bennyhartnett.com/projects'
+    );
+    expect(history.pushState).toHaveBeenCalledWith({ url: 'pages/projects.html' }, '', '/projects');
+    expect(document.dispatchEvent).toHaveBeenCalledWith(expect.objectContaining({ type: 'spa:content-loaded' }));
+    expect(document.body.dataset.page).toBe('projects');
+
+    vi.useRealTimers();
+  });
+
+  it('loads fallback content when fetch fails', async () => {
+    vi.useFakeTimers();
+
+    const container = {
+      classList: {
+        add: vi.fn(),
+        remove: vi.fn()
+      },
+      querySelector: vi.fn(() => null),
+      querySelectorAll: vi.fn(() => []),
+      innerHTML: '',
+      get offsetHeight() { return 0; }
+    };
+    const title = { addEventListener: vi.fn() };
+    document.querySelector = vi.fn((selector) => {
+      if (selector === '#main-content') return container;
+      if (selector === 'nav .title') return title;
+      return null;
+    });
+    initRouter();
+    await vi.runAllTimersAsync();
+
+    fetch.mockRejectedValueOnce(new Error('offline'));
+    loadContent('pages/privacy.html', false, true);
+    await vi.runAllTimersAsync();
+
+    expect(container.innerHTML).toContain('Privacy Policy');
+    expect(document.body.dataset.page).toBe('privacy');
+
+    vi.useRealTimers();
   });
 });

--- a/nuclear/nuclear-math.test.js
+++ b/nuclear/nuclear-math.test.js
@@ -376,6 +376,10 @@ describe('computeFeedEupFromSwu (Mode 4)', () => {
     expect(() => computeFeedEupFromSwu(LEU_5, TAILS_03, NATURAL_U, 0)).toThrow();
     expect(() => computeFeedEupFromSwu(LEU_5, TAILS_03, NATURAL_U, -10)).toThrow();
   });
+
+  it('should throw when SWU quantity is unrealistically large for search bounds', () => {
+    expect(() => computeFeedEupFromSwu(0.008, 0.0071, NATURAL_U, 1e12)).toThrow(/too large/);
+  });
 });
 
 // ============================================================================
@@ -449,6 +453,11 @@ describe('findOptimumTails (Mode 5)', () => {
       expect(result.xw).toBeLessThan(NATURAL_U);
       expect(result.cost_per_P).toBeGreaterThan(0);
     });
+  });
+
+  it('should throw when product assay is not greater than feed assay', () => {
+    expect(() => findOptimumTails(NATURAL_U, NATURAL_U, 100, 150)).toThrow(/Assay ordering is incorrect/);
+    expect(() => findOptimumTails(0.005, NATURAL_U, 100, 150)).toThrow(/Assay ordering is incorrect/);
   });
 });
 

--- a/sw.test.js
+++ b/sw.test.js
@@ -113,6 +113,29 @@ describe('sw.js service worker', () => {
     expect(caches.__activeCache.put).toHaveBeenCalled();
   });
 
+  it('returns cached response for approved CDN origins when present', async () => {
+    const request = new Request('https://cdn.jsdelivr.net/npm/three@0.1.0/build/three.min.js');
+    const cached = new Response('cached cdn', { status: 200 });
+    caches.__cacheStore.set(request.url, cached);
+    const event = makeFetchEvent(request);
+    handlers.fetch(event);
+
+    const response = await event.responsePromise;
+    expect(await response.text()).toBe('cached cdn');
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it('does not cache non-ok CDN responses', async () => {
+    const request = new Request('https://cdnjs.cloudflare.com/ajax/libs/three.js/r1/three.min.js');
+    fetch.mockResolvedValueOnce(new Response('bad', { status: 500 }));
+    const event = makeFetchEvent(request);
+    handlers.fetch(event);
+
+    const response = await event.responsePromise;
+    expect(response.status).toBe(500);
+    expect(caches.__activeCache.put).not.toHaveBeenCalled();
+  });
+
   it('bypasses non-whitelisted external origins', () => {
     const request = new Request('https://example.com/script.js');
     const event = makeFetchEvent(request);
@@ -148,9 +171,25 @@ describe('sw.js service worker', () => {
     expect(caches.__activeCache.put).toHaveBeenCalled();
   });
 
+  it('uses network-first strategy for /nuclear route', async () => {
+    const request = new Request('https://bennyhartnett.com/nuclear');
+    const event = makeFetchEvent(request);
+    handlers.fetch(event);
+
+    const response = await event.responsePromise;
+    expect(await response.text()).toBe('network');
+    expect(fetch).toHaveBeenCalledWith(request);
+  });
+
   it('handles skipWaiting message', () => {
     handlers.message({ data: 'skipWaiting' });
 
     expect(self.skipWaiting).toHaveBeenCalledTimes(1);
+  });
+
+  it('ignores non-skipWaiting messages', () => {
+    handlers.message({ data: 'noop' });
+
+    expect(self.skipWaiting).not.toHaveBeenCalled();
   });
 });

--- a/workers/router.test.js
+++ b/workers/router.test.js
@@ -57,6 +57,17 @@ describe('workers/router', () => {
     expect(fetchSpy).toHaveBeenCalledTimes(1);
   });
 
+  it('passes through root main-domain requests', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(makeResponse('root'));
+
+    const request = new Request('https://bennyhartnett.com/');
+    const response = await worker.fetch(request, {}, {});
+
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe('root');
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
   it('passes non-html file paths through on main domain', async () => {
     const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(makeResponse('file passthrough'));
 
@@ -103,6 +114,17 @@ describe('workers/router', () => {
     expect(String(url)).toBe('https://bennyhartnett.com/css/main.css');
     expect(init.method).toBe('GET');
     expect(init.headers.get('X-CF-Worker-Internal')).toBe('1');
+  });
+
+  it('passes .html static assets on subdomains through main domain', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(makeResponse('html asset'));
+
+    const response = await worker.fetch(new Request('https://contact.bennyhartnett.com/pages/contact.html'), {}, {});
+
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe('html asset');
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(String(fetchSpy.mock.calls[0][0])).toBe('https://bennyhartnett.com/pages/contact.html');
   });
 
   it('serves nuclear and centrus subdomains from /nuclear.html', async () => {
@@ -152,5 +174,27 @@ describe('workers/router', () => {
     expect(response.headers.get('content-type')).toContain('text/vcard');
     expect(response.headers.get('content-disposition')).toContain('Hartnett_Benny.vcf');
     expect(await response.text()).toBe('VCARD');
+  });
+
+  it('serves generic subdomain requests from root index', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(makeResponse('index shell'));
+
+    const response = await worker.fetch(new Request('https://projects.bennyhartnett.com/'), {}, {});
+
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe('index shell');
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(String(fetchSpy.mock.calls[0][0])).toBe('https://bennyhartnett.com/');
+  });
+
+  it('falls back to generic subdomain behavior for non-root card paths', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(makeResponse('index shell'));
+
+    const response = await worker.fetch(new Request('https://card.bennyhartnett.com/profile'), {}, {});
+
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe('index shell');
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(String(fetchSpy.mock.calls[0][0])).toBe('https://bennyhartnett.com/');
   });
 });


### PR DESCRIPTION
### Motivation
- Improve coverage for SPA router behavior including link handling, routing decisions, and content loading side effects.
- Verify service worker caching and fetch strategies for CDN origins and special routes like `/nuclear`.
- Harden worker routing tests for subdomain redirects, passthroughs, and special subdomain behaviors.
- Add edge-case validation to nuclear math utilities to ensure safe failure modes.

### Description
- Extended `js/spa-router.test.js` to mock `meta-manager` and `analytics`, import `initRouter` and `loadContent`, add richer DOM/`window`/`history`/`navigator` test globals, and add tests for link click cases, clipboard copy, secure resume download, router initialization, and `loadContent` updating meta/analytics/history.
- Added service worker tests in `sw.test.js` to assert cached CDN responses are returned when present, non-OK CDN responses are not cached, `/nuclear` uses network-first, and non-`skipWaiting` messages are ignored.
- Enhanced `workers/router.test.js` to cover root main-domain passthroughs, `.html` asset passthroughs from subdomains, generic subdomain index serving, and fallback behavior for non-root card paths.
- Added failure/validation tests to `nuclear/nuclear-math.test.js` to ensure extremely large SWU inputs throw and that `findOptimumTails` enforces correct assay ordering.

### Testing
- Ran the unit test suite with `vitest` covering `js/spa-router.test.js`, `sw.test.js`, `workers/router.test.js`, and `nuclear/nuclear-math.test.js`, and all tests passed.
- Exercised `initRouter` and `loadContent` flows and verified `updateMetaTags`, `trackPageView`, and history updates executed as expected.
- Executed service worker and worker routing tests validating caching strategies, redirects, passthroughs, and special-case subdomain behavior, and they succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e86a371e58832dafda0db2ad2f5412)