### PR TITLE
Preserve resume PDF transparency and bump service worker cache

### DIFF
--- a/pages/resume.html
+++ b/pages/resume.html
@@ -406,7 +406,9 @@
           var renderTask = page.render({
             canvasContext: context,
             viewport: viewport,
-            background: 'rgba(255, 255, 255, 0.35)'
+            // Preserve PDF alpha instead of compositing a white matte.
+            // This keeps page backgrounds transparent over the site canvas.
+            background: 'rgba(0, 0, 0, 0)'
           });
 
           // Render text layer for selectable/searchable text

--- a/sw.js
+++ b/sw.js
@@ -1,6 +1,6 @@
 // Service Worker for SWU Calculator PWA
 // Version must be updated when deploying new code to bust cache
-const CACHE_VERSION = 'v140';
+const CACHE_VERSION = 'v141';
 const CACHE_NAME = `swu-calculator-${CACHE_VERSION}`;
 
 // Files to cache for offline use


### PR DESCRIPTION
### Motivation
- The resume viewer was compositing a semi-opaque matte into rendered PDF pages which blocked the site background and prevented true transparency.

### Description
- Change `pages/resume.html` PDF.js render background to preserve alpha (`background: 'rgba(0, 0, 0, 0)'`) and bump service worker `CACHE_VERSION` in `sw.js` from `v140` to `v141` so clients fetch the updated page.

### Testing
- Ran `npm test` (Vitest) and all test suites passed (`98 tests, 0 failures`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e86db09664832d8677746fa9ddeeb6)