### PR TITLE
Full Spanish translation of Privacy Policy and service worker cache bump

### DIFF
--- a/pages/privacy.html
+++ b/pages/privacy.html
@@ -470,33 +470,385 @@
     <h1>Política de Privacidad y Términos de Uso</h1>
     <p><strong>BennyHartnett.com y sus subdominios</strong></p>
     <p>Última actualización: 22 de abril de 2026</p>
+
     <p>
-      Esta versión en español está disponible para accesibilidad y referencia rápida. En caso de
-      conflicto de interpretación, prevalece la versión en inglés de esta política.
+      Esta Política de Privacidad y Términos de Uso (&quot;Política&quot;) regula su acceso y uso de
+      bennyhartnett.com y de todos los subdominios, páginas, funciones, formularios, contenido,
+      herramientas y servicios relacionados (en conjunto, el &quot;Sitio&quot;). Al acceder, navegar,
+      usar, interactuar o enviar información a través del Sitio, usted reconoce que ha leído,
+      entendido y aceptado quedar vinculado por esta Política. Si no está de acuerdo, no debe
+      acceder ni usar el Sitio.
     </p>
+
     <p>
-      Este sitio puede recopilar información que usted proporcione voluntariamente (por ejemplo,
-      formularios o mensajes), además de información técnica y de uso (como dirección IP, tipo de
-      dispositivo, datos de navegación, cookies y registros operativos) para operar, proteger y
-      mejorar el servicio.
+      El Sitio es propiedad de y está operado por Benny Hartnett (&quot;Propietario&quot;, &quot;nosotros&quot;,
+      &quot;nos&quot; o &quot;nuestro&quot;). Las referencias a &quot;usted&quot; y &quot;su&quot; se refieren a cualquier persona o
+      entidad que acceda o use el Sitio.
     </p>
+
+    <h2>1. Elegibilidad y Licencia Limitada</h2>
     <p>
-      También podemos utilizar proveedores externos de infraestructura, análisis, automatización y
-      herramientas de IA para ofrecer funcionalidades del sitio. Esos proveedores pueden procesar
-      datos conforme a sus propias políticas y términos.
+      Usted declara que tiene capacidad legal para celebrar esta Política y para cumplir con todas
+      las leyes aplicables. Le otorgamos una licencia limitada, revocable, no exclusiva, no
+      transferible y no sublicenciable para acceder y usar el Sitio únicamente con fines
+      personales, informativos y lícitos. No se le transfieren derechos de propiedad ni otros
+      derechos.
     </p>
+
+    <h2>2. Cambios en el Sitio y en esta Política</h2>
     <p>
-      Al usar el sitio, usted acepta estos términos, incluido el uso de medidas de seguridad
-      razonables sin garantía absoluta, posibles transferencias internacionales de datos,
-      limitaciones de responsabilidad y uso del contenido solo con fines informativos.
+      Podemos modificar, suspender, restringir, discontinuar o reemplazar cualquier parte del Sitio
+      o de esta Política en cualquier momento, con o sin previo aviso, en la máxima medida permitida
+      por la ley. Salvo que indiquemos expresamente lo contrario, los cambios se aplican
+      prospectivamente desde la fecha en que se publiquen. Su uso continuado del Sitio después de
+      cualquier cambio publicado constituye su aceptación de la Política revisada.
     </p>
+
+    <h2>3. Información que Recopilamos</h2>
     <p>
-      Usted puede solicitar acceso, corrección o eliminación de datos cuando la ley aplicable lo
-      permita, escribiendo a <a href="mailto:me@bennyhartnett.com">me@bennyhartnett.com</a>.
+      Según cómo use el Sitio, nosotros o nuestros proveedores de servicios podemos recopilar y
+      procesar las siguientes categorías de información:
     </p>
+    <ul>
+      <li>
+        Información que usted envía voluntariamente, como su nombre, dirección de correo
+        electrónico, contenido de mensajes, indicaciones (prompts), archivos adjuntos,
+        comentarios u otra información que decida proporcionar mediante formularios de contacto,
+        herramientas de chat, correo electrónico o funciones similares.
+      </li>
+      <li>
+        Información de uso y del dispositivo, como páginas vistas, rutas de navegación, URL de
+        referencia, ubicación aproximada, tipo de navegador, tipo de dispositivo, sistema
+        operativo, datos de sesión, eventos de interacción y diagnósticos.
+      </li>
+      <li>
+        Información técnica y de red, como dirección IP, marcas de tiempo, metadatos de
+        solicitudes, cadenas de agente de usuario, registros de errores, señales de seguridad y
+        otros registros de infraestructura o CDN.
+      </li>
+      <li>
+        Información almacenada localmente, como preferencias, contenido en caché, datos de
+        enrutamiento o configuraciones almacenadas mediante cookies, almacenamiento local,
+        almacenamiento de sesión o service workers en su dispositivo.
+      </li>
+      <li>
+        Información generada a través de sus interacciones con funciones habilitadas por IA o
+        automatizadas, incluidas indicaciones, respuestas, historial de conversación, metadatos y
+        registros operativos mantenidos por nosotros o por nuestros proveedores externos.
+      </li>
+      <li>
+        Cualquier otra información que sea recopilada automáticamente por analítica, cookies,
+        píxeles, scripts, SDK u otras tecnologías similares usadas por nosotros o por proveedores
+        de servicios que respaldan el Sitio.
+      </li>
+    </ul>
+
+    <h2>4. Fuentes de Información</h2>
     <p>
-      Para ver todos los términos completos y detallados, seleccione <strong>English</strong> en
-      el selector de idioma.
+      Podemos recopilar información directamente de usted, automáticamente desde su dispositivo o
+      navegador, de servicios de terceros y proveedores de infraestructura, de herramientas de
+      analítica y antiabuso, y de fuentes públicas o lícitamente obtenidas.
+    </p>
+
+    <h2>5. Cómo Usamos la Información</h2>
+    <p>
+      En la máxima medida permitida por la ley, podemos usar la información que recopilamos o
+      recibimos para los siguientes fines:
+    </p>
+    <ul>
+      <li>operar, alojar, mantener, depurar, proteger, supervisar y mejorar el Sitio;</li>
+      <li>responder consultas, mensajes, solicitudes y comunicaciones de soporte;</li>
+      <li>
+        analizar tendencias de uso, medir rendimiento, prevenir abusos y detectar fraude, spam o
+        uso indebido;
+      </li>
+      <li>
+        desarrollar, entrenar, evaluar o mejorar funciones, flujos de trabajo, automatizaciones,
+        funcionalidades asistidas por IA y servicios relacionados, salvo prohibición por ley
+        aplicable o por acuerdo escrito expreso;
+      </li>
+      <li>
+        hacer cumplir esta Política, proteger derechos y bienes, e investigar posibles conductas
+        indebidas o incumplimientos;
+      </li>
+      <li>
+        cumplir obligaciones legales, solicitudes de reguladores o autoridades, órdenes judiciales
+        o procesos legales válidos; y
+      </li>
+      <li>
+        facilitar transacciones corporativas, reestructuración, diligencia, financiación, venta,
+        fusión, adquisición o transferencia de activos u operaciones.
+      </li>
+    </ul>
+
+    <h2>6. Divulgación de Información</h2>
+    <p>
+      Podemos divulgar información, en la máxima medida permitida por la ley, a proveedores de
+      alojamiento, proveedores de infraestructura, proveedores de analítica, proveedores cloud,
+      proveedores CDN, herramientas de comunicación, procesadores de formularios, proveedores de
+      pago o identidad cuando se utilicen, proveedores de IA o automatización, asesores
+      profesionales, aseguradoras, afiliadas, contratistas, adquirentes, sucesores, contrapartes
+      en transacciones, autoridades, reguladores, tribunales u otras partes cuando sea
+      razonablemente necesario para operar, proteger, mejorar, hacer cumplir, defender,
+      transferir o cerrar el Sitio. También podemos divulgar información en forma agregada o
+      desidentificada cuando la ley lo permita. No garantizamos que ningún tercero mantenga
+      determinadas prácticas de privacidad, seguridad o conservación, y su uso del Sitio reconoce
+      esas prácticas independientes de terceros.
+    </p>
+
+    <h2>7. Cookies, Analítica y Tecnologías Similares</h2>
+    <p>
+      El Sitio puede usar cookies, píxeles, almacenamiento local, almacenamiento de sesión,
+      tecnologías de caché, herramientas de analítica y tecnologías similares para recordar
+      preferencias, medir tráfico, mejorar funcionalidad, fortalecer seguridad y respaldar la
+      operación del Sitio. Es posible que pueda gestionar ciertas tecnologías mediante la
+      configuración de su navegador o dispositivo, pero deshabilitarlas puede afectar algunas
+      funciones. Cuando la ley aplicable requiera consentimiento para tecnologías específicas,
+      dicho consentimiento podrá solicitarse a través del Sitio o mediante controles de su
+      navegador o dispositivo.
+    </p>
+
+    <h2>8. Funciones de IA, Herramientas y Envíos del Usuario</h2>
+    <p>
+      Cualquier formulario, indicación, mensaje, comentario, idea, sugerencia, texto, archivo u
+      otro material que envíe a través del Sitio se proporciona bajo su propio riesgo. Salvo en la
+      medida prohibida por la ley aplicable o que se indique expresamente lo contrario, tales envíos
+      no son confidenciales, y usted nos otorga a nosotros y a nuestros proveedores una licencia
+      mundial, no exclusiva, libre de regalías, transferible y sublicenciable para alojar,
+      almacenar, reproducir, transmitir, analizar, adaptar, modificar, procesar, crear obras
+      derivadas, mostrar y usar de otro modo dichos envíos según sea razonablemente necesario para
+      operar, proteger, mejorar, probar, entrenar, evaluar, hacer cumplir y respaldar el Sitio y
+      servicios relacionados. No envíe información que no esté autorizado a divulgar o que espere
+      mantener privada, privilegiada o confidencial.
+    </p>
+
+    <h2>9. Conservación de Datos</h2>
+    <p>
+      Conservamos la información durante el tiempo que determinemos razonablemente necesario o útil
+      para los fines descritos en esta Política, para necesidades comerciales legítimas, respaldo y
+      archivo, resolución de disputas, cumplimiento de esta Política, o según lo exija o permita la
+      ley. Los periodos de conservación pueden variar según la categoría de información, el
+      contexto, la sensibilidad y los requisitos legales u operativos. Los proveedores externos
+      pueden conservar datos conforme a sus propias prácticas y políticas.
+    </p>
+
+    <h2>10. Seguridad de los Datos</h2>
+    <p>
+      Podemos utilizar medidas administrativas, técnicas y organizativas que consideremos razonables
+      a la luz de la naturaleza del Sitio y de los recursos disponibles. Sin embargo, ningún sitio
+      web, red, método de transmisión, entorno de almacenamiento, sistema de IA o servicio de
+      terceros es completamente seguro, libre de errores o inmune al acceso no autorizado,
+      interrupciones, interceptación, uso indebido, alteración o pérdida. No garantizamos la
+      seguridad, integridad, confidencialidad ni disponibilidad de ninguna información, y usted
+      asume todos los riesgos asociados con enviar información al Sitio o a través de él.
+    </p>
+
+    <h2>11. Transferencias Internacionales</h2>
+    <p>
+      El Sitio puede estar alojado, operado, respaldado o accesible en Estados Unidos y en otras
+      jurisdicciones. Al usar el Sitio y proporcionar información, usted entiende que su información
+      puede transferirse, procesarse y almacenarse en países que pueden tener leyes de privacidad o
+      protección de datos diferentes a las de su jurisdicción.
+    </p>
+
+    <h2>12. Sus Derechos de Privacidad</h2>
+    <p>
+      Dependiendo de su jurisdicción, puede tener ciertos derechos sobre información personal, que
+      pueden incluir solicitar acceso, corrección, eliminación, portabilidad, limitación, oposición
+      o exclusión voluntaria de ciertos tratamientos o divulgaciones. Cualesquiera de esos derechos
+      están sujetos a la ley aplicable, excepciones, procedimientos de verificación y a nuestra
+      capacidad para autenticar y satisfacer la solicitud mediante métodos comercialmente
+      razonables. Las solicitudes pueden enviarse a
+      <a href="mailto:me@bennyhartnett.com">me@bennyhartnett.com</a>. Podemos requerir
+      información razonablemente necesaria para verificar su solicitud y proteger contra fraude o
+      uso indebido.
+    </p>
+
+    <h2>13. Privacidad de Menores</h2>
+    <p>
+      El Sitio no está dirigido a menores de 13 años, y no solicitamos ni recopilamos
+      intencionalmente información personal de menores de 13 años a través del Sitio. Si cree que
+      un menor pudo haber proporcionado información personal a través del Sitio, contáctenos y
+      podremos tomar las medidas que consideremos apropiadas bajo la ley aplicable.
+    </p>
+
+    <h2>14. Servicios de Terceros y Enlaces Externos</h2>
+    <p>
+      El Sitio puede depender de, o enlazar a, servicios, plataformas, bibliotecas, fuentes,
+      CDN, proveedores de analítica, repositorios, plataformas sociales, contenido incrustado,
+      API, infraestructura o sitios web externos de terceros. Esas partes pueden recopilar datos
+      directamente de usted y se rigen por sus propios términos y políticas. No controlamos,
+      respaldamos, supervisamos ni asumimos responsabilidad por contenido, disponibilidad,
+      rendimiento, conducta, políticas o prácticas de datos de terceros. En la máxima medida
+      permitida por la ley, usted nos libera de reclamaciones derivadas de o relacionadas con
+      cualquier servicio de terceros, contenido, acto, omisión, interrupción, fallo,
+      incumplimiento o política.
+    </p>
+
+    <h2>15. Propiedad Intelectual</h2>
+    <p>
+      El Sitio y todo el contenido, diseño, maquetación, marca, gráficos, texto, software, código,
+      funciones y recopilaciones disponibles a través del Sitio son de nuestra propiedad o de
+      nuestros licenciantes y están protegidos por leyes aplicables de propiedad intelectual y
+      competencia desleal. Salvo la licencia limitada otorgada expresamente arriba, no se le concede
+      ningún derecho, título o interés. No puede copiar, reproducir, distribuir, republicar,
+      vender, licenciar, extraer datos, reflejar, enmarcar, modificar, crear obras derivadas,
+      realizar ingeniería inversa o explotar el Sitio, salvo autorización escrita expresa.
+    </p>
+
+    <h2>16. Conducta Prohibida</h2>
+    <p>Usted acepta no, y no ayudar ni permitir a otros:</p>
+    <ul>
+      <li>
+        usar el Sitio para fines ilícitos, fraudulentos, infractores, acosadores, abusivos,
+        difamatorios, invasivos o engañosos;
+      </li>
+      <li>
+        enviar virus, código malicioso, exploits, indicaciones dirigidas a eludir medidas de
+        seguridad u otro material dañino;
+      </li>
+      <li>
+        extraer, rastrear, cosechar, reflejar, copiar, minar o indexar el Sitio o sus salidas con
+        bots, scripts, automatización o métodos similares sin autorización previa por escrito;
+      </li>
+      <li>
+        interferir con el Sitio, degradar el rendimiento, sondear o probar vulnerabilidades,
+        eludir restricciones de acceso o intentar acceso no autorizado a sistemas, cuentas o datos;
+      </li>
+      <li>
+        usar contenido, salidas o datos del Sitio para crear, comparar, entrenar o mejorar
+        productos, modelos, conjuntos de datos o servicios competidores sin permiso escrito expreso;
+      </li>
+      <li>
+        enviar información confidencial, propietaria, personal, regulada o sensible, salvo que esté
+        plenamente autorizado para hacerlo y acepte todos los riesgos relacionados;
+      </li>
+      <li>
+        usar el Sitio o cualquier salida para decisiones legales, médicas, financieras,
+        de ingeniería, cumplimiento, emergencias u otras decisiones de alto riesgo; o
+      </li>
+      <li>tergiversar su identidad, afiliación, autoridad o derechos en relación con el Sitio.</li>
+    </ul>
+
+    <h2>17. Sin Deber de Supervisión; Derecho a Restringir o Eliminar</h2>
+    <p>
+      Nos reservamos el derecho, pero no la obligación, de supervisar, revisar, filtrar, registrar,
+      investigar, eliminar, deshabilitar, restringir, suspender, bloquear, conservar o divulgar
+      cualquier contenido, envío, acceso o actividad en o relacionada con el Sitio en cualquier
+      momento, con o sin aviso, por cualquier motivo o sin motivo, y sin responsabilidad.
+    </p>
+
+    <h2>18. IA, Calculadoras y Contenido Informativo — Sin Confianza</h2>
+    <p>
+      El Sitio puede incluir funciones asistidas por IA, salidas automatizadas, calculadoras,
+      contenido generado, contenido de blog, código, ejemplos, comentarios técnicos u otro material
+      informativo. Todos esos materiales se proporcionan únicamente con fines informativos,
+      educativos o experimentales generales. Pueden ser inexactos, incompletos, sesgados,
+      desactualizados, ofensivos, no disponibles o inadecuados para sus circunstancias. Usted es el
+      único responsable de evaluar, verificar y asumir todos los riesgos derivados de cualquier uso
+      de dichos materiales. El Sitio no está destinado ni debe utilizarse para fines legales,
+      médicos, financieros, de ingeniería, laborales, de cumplimiento, críticos para la seguridad o
+      de emergencia.
+    </p>
+
+    <h2>19. Exclusión de Garantías</h2>
+    <p>
+      EN LA MÁXIMA MEDIDA PERMITIDA POR LA LEY APLICABLE, EL SITIO Y TODO EL CONTENIDO,
+      FUNCIONALIDADES, SALIDAS, HERRAMIENTAS, SOFTWARE, MATERIALES, COMUNICACIONES Y SERVICIOS
+      DISPONIBLES A TRAVÉS DEL SITIO SE PROPORCIONAN &quot;TAL CUAL&quot;, &quot;SEGÚN DISPONIBILIDAD&quot;,
+      &quot;CON TODOS SUS DEFECTOS&quot; Y SIN GARANTÍAS NI DECLARACIONES DE NINGÚN TIPO, YA SEAN
+      EXPRESAS, IMPLÍCITAS, LEGALES O DE OTRO TIPO. RECHAZAMOS, EN LA MÁXIMA MEDIDA PERMITIDA POR
+      LA LEY, TODAS LAS GARANTÍAS, INCLUIDAS GARANTÍAS IMPLÍCITAS DE COMERCIABILIDAD, IDONEIDAD
+      PARA UN FIN PARTICULAR, TITULARIDAD, NO INFRACCIÓN, DISFRUTE PACÍFICO, INTEGRACIÓN DE
+      SISTEMAS, PRECISIÓN DE DATOS Y AUSENCIA DE INTERRUPCIONES, ERRORES, VIRUS, COMPONENTES
+      DAÑINOS O FALLOS DE SEGURIDAD. NO GARANTIZAMOS QUE EL SITIO SATISFAGA SUS REQUISITOS O
+      EXPECTATIVAS NI QUE SE CORRIJAN DEFECTOS.
+    </p>
+
+    <h2>20. Limitación de Responsabilidad</h2>
+    <p>
+      EN LA MÁXIMA MEDIDA PERMITIDA POR LA LEY APLICABLE, EN NINGÚN CASO EL PROPIETARIO NI
+      NINGUNA DE SUS AFILIADAS, LICENCIANTES, PROVEEDORES DE SERVICIOS, VENDEDORES,
+      CONTRATISTAS, ASESORES, AGENTES O REPRESENTANTES SERÁN RESPONSABLES POR DAÑOS DIRECTOS,
+      INDIRECTOS, INCIDENTALES, ESPECIALES, CONSECUENTES, EJEMPLARES, PUNITIVOS U OTROS DAÑOS, NI
+      POR PÉRDIDAS DE BENEFICIOS, INGRESOS, NEGOCIO, OPORTUNIDAD, DATOS, USO, BUENA VOLUNTAD,
+      AHORROS U OTRAS PÉRDIDAS INTANGIBLES, QUE SURJAN DE O SE RELACIONEN CON EL SITIO, ESTA
+      POLÍTICA, SERVICIOS DE TERCEROS, CONTENIDO DEL SITIO, SALIDAS DE IA, ENVÍOS DE USUARIOS,
+      INCIDENTES DE SEGURIDAD, TIEMPO DE INACTIVIDAD, ERRORES O SU ACCESO, USO, IMPOSIBILIDAD DE
+      USAR O CONFIANZA EN EL SITIO, YA SEA CON BASE EN CONTRATO, RESPONSABILIDAD EXTRACONTRACTUAL,
+      NEGLIGENCIA, RESPONSABILIDAD ESTRICTA, ESTATUTO O CUALQUIER OTRA TEORÍA, AUN SI SE ADVIRTIÓ
+      DE LA POSIBILIDAD DE DICHOS DAÑOS. EN LA MÁXIMA MEDIDA PERMITIDA POR LA LEY, NUESTRA
+      RESPONSABILIDAD TOTAL ACUMULADA POR TODAS LAS RECLAMACIONES QUE SURJAN DE O SE RELACIONEN
+      CON EL SITIO O ESTA POLÍTICA NO EXCEDERÁ EL MAYOR ENTRE UN DÓLAR ESTADOUNIDENSE (US $1.00)
+      Y EL MONTO, SI LO HUBIERE, QUE USTED NOS HAYA PAGADO DIRECTAMENTE POR USAR EL SITIO EN LOS
+      DOCE (12) MESES ANTERIORES AL HECHO QUE DIO ORIGEN A LA RECLAMACIÓN.
+    </p>
+
+    <h2>21. Indemnización</h2>
+    <p>
+      Usted acepta defender, indemnizar y eximir de responsabilidad al Propietario y a sus
+      afiliadas, licenciantes, proveedores de servicios, contratistas, vendedores, asesores,
+      agentes y representantes frente a toda reclamación, demanda, acción, procedimiento,
+      responsabilidad, daños, sentencias, laudos, pérdidas, costos y gastos, incluidos honorarios
+      y costos razonables de abogados, que surjan de o se relacionen con su acceso o uso del Sitio,
+      sus envíos, su incumplimiento de esta Política, su violación de la ley o su infracción o
+      violación de derechos de otra persona o entidad.
+    </p>
+
+    <h2>22. Terminación</h2>
+    <p>
+      Podemos terminar o suspender su acceso al Sitio, total o parcialmente, en cualquier momento,
+      con o sin aviso, por cualquier motivo o sin motivo, y sin responsabilidad. Tras la
+      terminación, los derechos y licencias otorgados a usted cesarán de inmediato, pero todas las
+      disposiciones que por su naturaleza deban subsistir subsistirán, incluidas las relativas a
+      propiedad, envíos, exclusiones de responsabilidad, limitaciones de responsabilidad,
+      liberaciones, indemnización, resolución de disputas e interpretación.
+    </p>
+
+    <h2>23. Resolución de Disputas, Ley Aplicable y Jurisdicción</h2>
+    <p>
+      En la máxima medida permitida por la ley, esta Política y cualquier disputa, reclamación o
+      controversia que surja de o se relacione con el Sitio o esta Política se regirá por las leyes
+      del Estado de Maryland y de Estados Unidos, sin considerar principios de conflicto de leyes.
+      Cualquier disputa de este tipo deberá presentarse exclusivamente en los tribunales estatales o
+      federales ubicados en Maryland, y usted consiente irrevocablemente la jurisdicción personal y
+      competencia territorial de dichos tribunales. Usted renuncia a cualquier objeción basada en
+      forum non conveniens o doctrina similar. También renuncia, en la máxima medida permitida por
+      la ley, a cualquier derecho a juicio por jurado en relación con cualquier disputa que surja de
+      o se relacione con el Sitio o esta Política.
+    </p>
+
+    <h2>24. Renuncia a Acción Colectiva y Límite de Tiempo</h2>
+    <p>
+      EN LA MÁXIMA MEDIDA PERMITIDA POR LA LEY, USTED Y EL PROPIETARIO ACUERDAN QUE CUALQUIER
+      RECLAMACIÓN O PROCEDIMIENTO SE PRESENTARÁ SOLO A TÍTULO INDIVIDUAL Y NO COMO DEMANDANTE,
+      MIEMBRO DE CLASE O REPRESENTANTE EN NINGUNA ACCIÓN O PROCEDIMIENTO PRESUNTAMENTE COLECTIVO,
+      CONSOLIDADO, MASIVO O REPRESENTATIVO. EN LA MÁXIMA MEDIDA PERMITIDA POR LA LEY, CUALQUIER
+      RECLAMACIÓN QUE SURJA DE O SE RELACIONE CON EL SITIO O ESTA POLÍTICA DEBE PRESENTARSE DENTRO
+      DE UN (1) AÑO DESDE QUE SURGIÓ LA RECLAMACIÓN O QUEDARÁ PERMANENTEMENTE EXCLUIDA.
+    </p>
+
+    <h2>25. Divisibilidad; No Renuncia; Acuerdo Completo; Cesión</h2>
+    <p>
+      Si alguna disposición de esta Política se considera inválida, ilegal o inaplicable, dicha
+      disposición se aplicará en la máxima medida permitida y las disposiciones restantes
+      permanecerán en pleno vigor y efecto. Ninguna renuncia a cualquier disposición será efectiva
+      salvo por escrito y firmada por el Propietario. Esta Política constituye el acuerdo completo
+      entre usted y el Propietario respecto del Sitio y reemplaza todos los entendimientos previos
+      o contemporáneos relacionados con el Sitio. Podemos ceder, transferir o delegar esta Política
+      y cualquier derecho u obligación en virtud de ella, total o parcialmente, sin restricción.
+      Usted no puede ceder esta Política sin nuestro consentimiento previo por escrito.
+    </p>
+
+    <h2>26. Contacto</h2>
+    <p>
+      Para preguntas o solicitudes relacionadas con esta Política, contacte a:
+      <a href="mailto:me@bennyhartnett.com">me@bennyhartnett.com</a>
+    </p>
+
+    <p>
+      Este documento está destinado a publicarse en el Sitio como Política de Privacidad y Términos
+      de Uso rectores.
     </p>
   </section>
 

--- a/sw.js
+++ b/sw.js
@@ -1,6 +1,6 @@
 // Service Worker for SWU Calculator PWA
 // Version must be updated when deploying new code to bust cache
-const CACHE_VERSION = 'v141';
+const CACHE_VERSION = 'v142';
 const CACHE_NAME = `swu-calculator-${CACHE_VERSION}`;
 
 // Files to cache for offline use


### PR DESCRIPTION
### Motivation
- Ensure the Spanish privacy section is a complete, section-by-section translation of the English policy so Spanish-speaking visitors have the same legal text and detail.
- Preserve the existing bilingual UX (language selector and toggle) while increasing content parity between languages.
- Ensure updated content is served to clients by incrementing the service worker cache version.

### Description
- Replaced the abbreviated Spanish content in the `<section data-language-content="es">` block of `pages/privacy.html` with a full Spanish translation mirroring the English policy structure and clauses (sections 1–26). 
- Left the language switcher and client-side toggle logic unchanged so the `en`/`es` selector and `localStorage` behavior continue to work as before (`pages/privacy.html` script unchanged). 
- Bumped the service worker `CACHE_VERSION` in `sw.js` from `v141` to `v142` so the updated `pages/privacy.html` is cached and served after deployment.

### Testing
- Ran `npm test` (Vitest) and all automated tests passed: 6 test files, 98 tests (all passing).
- Verified the site files changed are `pages/privacy.html` and `sw.js` and no other unit tests were affected by the content update.
- Confirmed the language selector script still toggles `data-language-content` sections and persists selection to `localStorage` during a manual inspection of the changed file.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e86e406f3c832d920837734fa389a3)