### PR TITLE
Prevent stale workflow from auto-closing inactive pull requests

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,14 @@
+# Configuration for actions/stale (including org-level/reusable workflows).
+# Keep stale labeling behavior, but never auto-close pull requests.
+daysUntilStale: 14
+daysUntilClose: -1
+
+# Apply this to PRs only.
+only: pulls
+
+# Keep labels explicit for maintainers.
+staleLabel: stale
+
+markComment: >-
+  This pull request has been marked stale due to 14 days of inactivity.
+  It will remain open and can be reactivated with new activity.


### PR DESCRIPTION
### Motivation
- Add an explicit repository-level stale configuration so pull requests are marked stale but not automatically closed after two weeks.

### Description
- Create `.github/stale.yml` that sets `daysUntilStale: 14`, disables auto-close with `daysUntilClose: -1`, scopes the action to `only: pulls`, keeps `staleLabel: stale`, and provides a `markComment` explaining that the PR will remain open.

### Testing
- No automated tests were run because this is a configuration-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e86f2bae7c832daddafd1440809c85)