### PR TITLE
Add French and Italian privacy translations, enable selector for them, and bump SW cache version

### DIFF
--- a/pages/privacy.html
+++ b/pages/privacy.html
@@ -101,6 +101,8 @@
     <select id="policy-language" aria-label="Select policy language">
       <option value="en">English</option>
       <option value="es">Español</option>
+      <option value="fr">Français</option>
+      <option value="it">Italiano</option>
     </select>
   </div>
 
@@ -852,6 +854,450 @@
     </p>
   </section>
 
+  <section data-language-content="fr">
+    <h1>Politique de confidentialité et conditions d'utilisation</h1>
+    <p><strong>BennyHartnett.com et ses sous-domaines</strong></p>
+    <p>Dernière mise à jour : 22 avril 2026</p>
+
+    <p>
+      La présente Politique de confidentialité et conditions d'utilisation («&nbsp;Politique&nbsp;») régit
+      votre accès et votre utilisation de bennyhartnett.com et de tous les sous-domaines, pages,
+      fonctionnalités, formulaires, contenus, outils et services associés (collectivement, le
+      «&nbsp;Site&nbsp;»). En accédant au Site, en le parcourant, en l'utilisant, en interagissant avec lui
+      ou en y soumettant des informations, vous reconnaissez avoir lu, compris et accepté d'être lié
+      par cette Politique. Si vous n'êtes pas d'accord, vous ne devez pas accéder au Site ni
+      l'utiliser.
+    </p>
+
+    <p>
+      Le Site est détenu et exploité par Benny Hartnett («&nbsp;Propriétaire&nbsp;», «&nbsp;nous&nbsp;», «&nbsp;notre&nbsp;»).
+      Les références à «&nbsp;vous&nbsp;» et «&nbsp;votre&nbsp;» désignent toute personne ou entité accédant au Site
+      ou l'utilisant.
+    </p>
+
+    <h2>1. Éligibilité et licence limitée</h2>
+    <p>
+      Vous déclarez être légalement habilité à conclure cette Politique et à respecter toutes les
+      lois applicables. Nous vous accordons une licence limitée, révocable, non exclusive,
+      non transférable et non sous-licenciable pour accéder au Site et l'utiliser uniquement à des
+      fins personnelles, informatives et licites. Aucun droit de propriété ne vous est transféré.
+    </p>
+
+    <h2>2. Modifications du Site et de la Politique</h2>
+    <p>
+      Nous pouvons modifier, suspendre, restreindre, interrompre ou remplacer toute partie du Site
+      ou de cette Politique à tout moment, avec ou sans préavis, dans les limites autorisées par la
+      loi. Sauf indication contraire expresse, les changements s'appliquent de manière prospective à
+      partir de leur date de publication. Votre utilisation continue du Site après publication d'une
+      modification vaut acceptation de la Politique révisée.
+    </p>
+
+    <h2>3. Informations que nous collectons</h2>
+    <p>
+      Selon votre utilisation du Site, nous ou nos prestataires pouvons collecter et traiter les
+      catégories d'informations suivantes :
+    </p>
+    <ul>
+      <li>Informations que vous soumettez volontairement (nom, e-mail, messages, pièces jointes, retours, etc.).</li>
+      <li>Informations d'usage et d'appareil (pages vues, navigation, type de navigateur, système, événements, diagnostics).</li>
+      <li>Informations techniques et réseau (adresse IP, horodatages, métadonnées de requêtes, journaux d'erreurs et de sécurité).</li>
+      <li>Informations stockées localement (préférences, cache, cookies, localStorage, sessionStorage, service workers).</li>
+      <li>Informations générées via les fonctionnalités d'IA ou automatisées (prompts, réponses, historique, métadonnées, journaux).</li>
+      <li>Autres informations collectées via outils d'analyse, pixels, scripts, SDK et technologies similaires.</li>
+    </ul>
+
+    <h2>4. Sources des informations</h2>
+    <p>
+      Nous pouvons collecter des informations directement auprès de vous, automatiquement via votre
+      appareil ou navigateur, via des prestataires tiers et infrastructures, des outils d'analyse et
+      de lutte contre les abus, ainsi que des sources publiques ou obtenues légalement.
+    </p>
+
+    <h2>5. Utilisation des informations</h2>
+    <p>Dans la mesure autorisée par la loi, nous pouvons utiliser les informations pour :</p>
+    <ul>
+      <li>exploiter, héberger, maintenir, sécuriser, surveiller et améliorer le Site ;</li>
+      <li>répondre à vos messages, demandes et besoins d'assistance ;</li>
+      <li>analyser l'utilisation, prévenir les abus et détecter fraude, spam ou mauvais usages ;</li>
+      <li>développer, entraîner, évaluer et améliorer les fonctionnalités, automatisations et services liés ;</li>
+      <li>faire respecter cette Politique et protéger les droits, biens et la sécurité ;</li>
+      <li>respecter les obligations légales et demandes des autorités compétentes ;</li>
+      <li>faciliter les opérations d'entreprise (fusion, acquisition, cession, financement, restructuration).</li>
+    </ul>
+
+    <h2>6. Divulgation des informations</h2>
+    <p>
+      Nous pouvons divulguer des informations, dans la mesure permise par la loi, à des hébergeurs,
+      fournisseurs d'infrastructure et d'analyse, prestataires cloud/CDN, outils de communication,
+      sous-traitants, conseillers professionnels, assureurs, affiliés, acquéreurs potentiels,
+      autorités publiques ou autres parties lorsque cela est raisonnablement nécessaire à
+      l'exploitation, la sécurité, l'amélioration, l'application, la défense, le transfert ou la
+      clôture du Site. Nous pouvons également divulguer des données agrégées ou désidentifiées.
+    </p>
+
+    <h2>7. Cookies, analyse et technologies similaires</h2>
+    <p>
+      Le Site peut utiliser des cookies, pixels et technologies similaires pour mémoriser les
+      préférences, mesurer le trafic, améliorer les fonctionnalités et renforcer la sécurité.
+      Vous pouvez gérer certaines préférences via votre navigateur ou appareil, mais la désactivation
+      peut limiter certaines fonctions.
+    </p>
+
+    <h2>8. Fonctionnalités IA, outils et soumissions</h2>
+    <p>
+      Tout contenu que vous soumettez via le Site est fourni à vos propres risques. Sauf interdiction
+      légale, ces soumissions ne sont pas confidentielles et vous nous accordez, ainsi qu'à nos
+      prestataires, une licence mondiale, non exclusive, transférable, sous-licenciable et sans
+      redevance pour héberger, stocker, reproduire, transmettre, analyser, adapter, modifier et
+      utiliser ces soumissions dans la mesure raisonnablement nécessaire au fonctionnement,
+      à l'amélioration et au support du Site.
+    </p>
+
+    <h2>9. Conservation des données</h2>
+    <p>
+      Nous conservons les informations aussi longtemps que nécessaire aux finalités décrites, à des
+      besoins commerciaux légitimes, à l'archivage et aux obligations légales. Les durées de
+      conservation varient selon la nature des données et le contexte.
+    </p>
+
+    <h2>10. Sécurité des données</h2>
+    <p>
+      Nous pouvons appliquer des mesures administratives, techniques et organisationnelles
+      raisonnables. Toutefois, aucun système n'est totalement sûr ni exempt d'interruptions,
+      d'accès non autorisés ou de pertes.
+    </p>
+
+    <h2>11. Transferts internationaux</h2>
+    <p>
+      Le Site peut être hébergé et exploité aux États-Unis et dans d'autres pays. En utilisant le
+      Site, vous comprenez que vos données peuvent être transférées et traitées dans des juridictions
+      dont les lois de protection des données peuvent différer de celles de votre pays.
+    </p>
+
+    <h2>12. Vos droits en matière de confidentialité</h2>
+    <p>
+      Selon votre juridiction, vous pouvez disposer de droits d'accès, de rectification,
+      d'effacement, de portabilité, de limitation, d'opposition ou de retrait pour certains
+      traitements. Pour exercer vos droits, contactez-nous à
+      <a href="mailto:me@bennyhartnett.com">me@bennyhartnett.com</a>.
+    </p>
+
+    <h2>13. Vie privée des enfants</h2>
+    <p>
+      Le Site n'est pas destiné aux enfants de moins de 13 ans, et nous ne collectons pas
+      sciemment de données personnelles auprès d'eux. Si vous pensez qu'un enfant nous a fourni des
+      données, contactez-nous.
+    </p>
+
+    <h2>14. Services tiers et liens externes</h2>
+    <p>
+      Le Site peut utiliser des services tiers ou contenir des liens externes. Ces tiers sont régis
+      par leurs propres conditions et politiques, que nous ne contrôlons pas.
+    </p>
+
+    <h2>15. Propriété intellectuelle</h2>
+    <p>
+      Le Site et son contenu (design, marques, code, textes, graphiques, fonctionnalités) nous
+      appartiennent ou appartiennent à nos concédants. Sauf licence limitée ci-dessus, aucun droit
+      ne vous est cédé.
+    </p>
+
+    <h2>16. Conduites interdites</h2>
+    <p>Vous acceptez de ne pas :</p>
+    <ul>
+      <li>utiliser le Site à des fins illicites, frauduleuses ou abusives ;</li>
+      <li>soumettre du code malveillant, des virus ou des tentatives de contournement de sécurité ;</li>
+      <li>extraire massivement, copier ou indexer le Site sans autorisation écrite ;</li>
+      <li>perturber le Site ou tenter d'accéder sans autorisation à des systèmes ou données ;</li>
+      <li>utiliser le Site pour entraîner des services concurrents sans autorisation ;</li>
+      <li>soumettre des données sensibles sans autorisation adéquate ;</li>
+      <li>utiliser le Site pour des décisions juridiques, médicales, financières ou de sécurité critique ;</li>
+      <li>usurper votre identité ou vos droits.</li>
+    </ul>
+
+    <h2>17. Absence d'obligation de surveillance</h2>
+    <p>
+      Nous nous réservons le droit, sans obligation, de surveiller, examiner, supprimer,
+      restreindre ou divulguer des contenus ou activités liés au Site.
+    </p>
+
+    <h2>18. IA, calculateurs et contenus informatifs — pas de confiance aveugle</h2>
+    <p>
+      Les contenus du Site peuvent être inexacts, incomplets ou inadaptés à votre situation. Vous
+      êtes seul responsable de la vérification et de l'usage que vous en faites.
+    </p>
+
+    <h2>19. Exclusion de garanties</h2>
+    <p>
+      DANS LES LIMITES AUTORISÉES PAR LA LOI, LE SITE EST FOURNI « EN L'ÉTAT » ET « SELON
+      DISPONIBILITÉ », SANS GARANTIES D'AUCUNE SORTE.
+    </p>
+
+    <h2>20. Limitation de responsabilité</h2>
+    <p>
+      DANS LES LIMITES AUTORISÉES PAR LA LOI, NOUS NE SERONS PAS RESPONSABLES DES DOMMAGES DIRECTS
+      OU INDIRECTS LIÉS À L'UTILISATION DU SITE. NOTRE RESPONSABILITÉ TOTALE CUMULÉE N'EXCÉDERA PAS
+      LE PLUS ÉLEVÉ ENTRE 1,00 USD ET LE MONTANT QUE VOUS NOUS AVEZ DIRECTEMENT PAYÉ AU COURS DES
+      12 DERNIERS MOIS.
+    </p>
+
+    <h2>21. Indemnisation</h2>
+    <p>
+      Vous acceptez de nous indemniser pour toute réclamation liée à votre utilisation du Site,
+      vos soumissions, la violation de cette Politique ou d'une loi applicable.
+    </p>
+
+    <h2>22. Résiliation</h2>
+    <p>
+      Nous pouvons suspendre ou résilier votre accès au Site à tout moment, avec ou sans préavis.
+      Les dispositions qui, par nature, doivent survivre à la résiliation continueront de s'appliquer.
+    </p>
+
+    <h2>23. Droit applicable et juridiction</h2>
+    <p>
+      Cette Politique est régie par les lois de l'État du Maryland et des États-Unis. Tout litige
+      relève exclusivement des tribunaux étatiques ou fédéraux situés dans le Maryland.
+    </p>
+
+    <h2>24. Renonciation aux actions collectives et délai</h2>
+    <p>
+      DANS LES LIMITES AUTORISÉES PAR LA LOI, TOUTE RÉCLAMATION DOIT ÊTRE PORTÉE À TITRE
+      INDIVIDUEL ET INTRODUITE DANS UN DÉLAI D'UN (1) AN À COMPTER DE SA NAISSANCE.
+    </p>
+
+    <h2>25. Divisibilité, renonciation, intégralité, cession</h2>
+    <p>
+      Si une clause est invalide, les autres restent en vigueur. Aucune renonciation n'est valable
+      sans écrit signé. Cette Politique constitue l'accord intégral entre vous et le Propriétaire.
+      Nous pouvons céder nos droits et obligations ; vous ne pouvez pas céder les vôtres sans
+      consentement écrit préalable.
+    </p>
+
+    <h2>26. Contact</h2>
+    <p>
+      Pour toute question relative à cette Politique, contactez
+      <a href="mailto:me@bennyhartnett.com">me@bennyhartnett.com</a>.
+    </p>
+
+    <p>
+      Ce document est publié sur le Site en tant que Politique de confidentialité et conditions
+      d'utilisation de référence.
+    </p>
+  </section>
+
+  <section data-language-content="it">
+    <h1>Informativa sulla privacy e termini di utilizzo</h1>
+    <p><strong>BennyHartnett.com e i suoi sottodomini</strong></p>
+    <p>Ultimo aggiornamento: 22 aprile 2026</p>
+
+    <p>
+      La presente Informativa sulla privacy e termini di utilizzo ("Politica") disciplina
+      l'accesso e l'uso di bennyhartnett.com e di tutti i sottodomini, le pagine, le funzionalità,
+      i moduli, i contenuti, gli strumenti e i servizi correlati (collettivamente, il "Sito").
+      Accedendo, navigando, utilizzando o inviando informazioni tramite il Sito, dichiari di aver
+      letto, compreso e accettato questa Politica. Se non sei d'accordo, non devi utilizzare il Sito.
+    </p>
+
+    <p>
+      Il Sito è di proprietà e gestito da Benny Hartnett ("Titolare", "noi", "nostro").
+      I riferimenti a "tu" e "tuo" indicano qualsiasi persona o entità che accede o usa il Sito.
+    </p>
+
+    <h2>1. Idoneità e licenza limitata</h2>
+    <p>
+      Dichiari di avere la capacità legale per aderire a questa Politica e rispettare tutte le leggi
+      applicabili. Ti concediamo una licenza limitata, revocabile, non esclusiva, non trasferibile e
+      non sublicenziabile per accedere e usare il Sito solo per finalità personali, informative e
+      lecite. Nessun diritto di proprietà ti viene trasferito.
+    </p>
+
+    <h2>2. Modifiche al Sito e alla Politica</h2>
+    <p>
+      Possiamo modificare, sospendere, limitare, interrompere o sostituire qualsiasi parte del Sito
+      o di questa Politica in qualsiasi momento, con o senza preavviso, nei limiti consentiti dalla
+      legge. Salvo diversa indicazione, le modifiche si applicano dal momento della pubblicazione.
+    </p>
+
+    <h2>3. Informazioni che raccogliamo</h2>
+    <p>
+      In base a come utilizzi il Sito, noi o i nostri fornitori possiamo raccogliere e trattare:
+    </p>
+    <ul>
+      <li>informazioni inviate volontariamente (nome, e-mail, messaggi, allegati, feedback, ecc.);</li>
+      <li>dati di utilizzo e dispositivo (pagine visitate, percorsi, browser, sistema operativo, eventi);</li>
+      <li>dati tecnici e di rete (indirizzo IP, timestamp, metadati delle richieste, log di sicurezza);</li>
+      <li>dati memorizzati localmente (preferenze, cache, cookie, localStorage, sessionStorage, service worker);</li>
+      <li>dati generati dall'interazione con funzionalità IA o automatizzate (prompt, risposte, cronologia, metadati);</li>
+      <li>altri dati raccolti da strumenti di analisi, pixel, script, SDK e tecnologie simili.</li>
+    </ul>
+
+    <h2>4. Fonti delle informazioni</h2>
+    <p>
+      Possiamo raccogliere informazioni direttamente da te, automaticamente dal tuo dispositivo o
+      browser, da servizi di terze parti e da fonti pubbliche o ottenute lecitamente.
+    </p>
+
+    <h2>5. Come usiamo le informazioni</h2>
+    <p>Nei limiti consentiti dalla legge, possiamo usare le informazioni per:</p>
+    <ul>
+      <li>gestire, ospitare, mantenere, proteggere e migliorare il Sito;</li>
+      <li>rispondere a richieste, messaggi e comunicazioni di supporto;</li>
+      <li>analizzare l'uso, prevenire abusi e rilevare frodi, spam o uso improprio;</li>
+      <li>sviluppare, addestrare, valutare o migliorare funzionalità, automazioni e servizi correlati;</li>
+      <li>far rispettare questa Politica e tutelare diritti e proprietà;</li>
+      <li>adempiere a obblighi legali o richieste delle autorità;</li>
+      <li>supportare operazioni societarie (ristrutturazioni, fusioni, acquisizioni, trasferimenti).</li>
+    </ul>
+
+    <h2>6. Divulgazione delle informazioni</h2>
+    <p>
+      Possiamo divulgare informazioni, nei limiti consentiti dalla legge, a fornitori di hosting,
+      infrastruttura, analytics, cloud/CDN, consulenti professionali, affiliate, controparti in
+      transazioni societarie, autorità pubbliche o altri soggetti quando ragionevolmente necessario.
+    </p>
+
+    <h2>7. Cookie, analytics e tecnologie simili</h2>
+    <p>
+      Il Sito può usare cookie e tecnologie simili per ricordare preferenze, misurare traffico,
+      migliorare funzionalità e sicurezza. La disattivazione di alcune tecnologie può ridurre
+      determinate funzionalità.
+    </p>
+
+    <h2>8. Funzionalità IA, strumenti e contenuti inviati</h2>
+    <p>
+      Qualsiasi contenuto inviato tramite il Sito è fornito a tuo rischio. Salvo divieti di legge,
+      tali invii non sono confidenziali e ci concedi una licenza mondiale, non esclusiva,
+      trasferibile, sublicenziabile e gratuita per usarli nella misura necessaria al funzionamento,
+      miglioramento e supporto del Sito.
+    </p>
+
+    <h2>9. Conservazione dei dati</h2>
+    <p>
+      Conserviamo i dati per il tempo ragionevolmente necessario agli scopi descritti, per esigenze
+      legittime di business e per obblighi legali. I periodi di conservazione possono variare.
+    </p>
+
+    <h2>10. Sicurezza dei dati</h2>
+    <p>
+      Possiamo adottare misure amministrative, tecniche e organizzative ragionevoli, ma nessun
+      sistema è completamente sicuro o privo di interruzioni e accessi non autorizzati.
+    </p>
+
+    <h2>11. Trasferimenti internazionali</h2>
+    <p>
+      Il Sito può essere ospitato o gestito negli Stati Uniti e in altre giurisdizioni. Usando il
+      Sito, accetti che i dati possano essere trasferiti e trattati in paesi con norme diverse.
+    </p>
+
+    <h2>12. I tuoi diritti sulla privacy</h2>
+    <p>
+      A seconda della giurisdizione, potresti avere diritti di accesso, rettifica, cancellazione,
+      portabilità, limitazione, opposizione o opt-out. Per richieste, scrivi a
+      <a href="mailto:me@bennyhartnett.com">me@bennyhartnett.com</a>.
+    </p>
+
+    <h2>13. Privacy dei minori</h2>
+    <p>
+      Il Sito non è rivolto a minori di 13 anni e non raccogliamo intenzionalmente dati personali da
+      minori di 13 anni.
+    </p>
+
+    <h2>14. Servizi di terze parti e link esterni</h2>
+    <p>
+      Il Sito può integrare o collegare servizi di terze parti. Tali soggetti sono regolati dai loro
+      termini e informative, che non controlliamo.
+    </p>
+
+    <h2>15. Proprietà intellettuale</h2>
+    <p>
+      Il Sito e i relativi contenuti (design, codice, testi, marchi, funzionalità) appartengono a
+      noi o ai nostri licenzianti. Salvo la licenza limitata sopra, non ti viene concesso alcun
+      diritto ulteriore.
+    </p>
+
+    <h2>16. Condotte vietate</h2>
+    <p>Accetti di non:</p>
+    <ul>
+      <li>usare il Sito per scopi illeciti, fraudolenti o abusivi;</li>
+      <li>inviare malware, virus o materiale dannoso;</li>
+      <li>estrarre, copiare o indicizzare il Sito senza autorizzazione scritta;</li>
+      <li>interferire con il Sito o tentare accessi non autorizzati;</li>
+      <li>usare contenuti/dati del Sito per addestrare servizi concorrenti senza consenso;</li>
+      <li>inviare dati sensibili senza adeguata autorizzazione;</li>
+      <li>usare il Sito per decisioni legali, mediche, finanziarie o ad alto rischio;</li>
+      <li>falsare identità, affiliazione o diritti.</li>
+    </ul>
+
+    <h2>17. Nessun obbligo di monitoraggio</h2>
+    <p>
+      Ci riserviamo il diritto, ma non l'obbligo, di monitorare, esaminare, rimuovere o limitare
+      contenuti, invii o attività relativi al Sito.
+    </p>
+
+    <h2>18. IA, calcolatori e contenuti informativi — nessun affidamento</h2>
+    <p>
+      I contenuti del Sito possono essere inaccurati, incompleti o non adatti al tuo caso. Sei
+      responsabile della verifica indipendente e dell'uso che ne fai.
+    </p>
+
+    <h2>19. Esclusione di garanzie</h2>
+    <p>
+      NEI LIMITI MASSIMI CONSENTITI DALLA LEGGE, IL SITO È FORNITO "COSÌ COM'È" E "COME
+      DISPONIBILE", SENZA GARANZIE DI ALCUN TIPO.
+    </p>
+
+    <h2>20. Limitazione di responsabilità</h2>
+    <p>
+      NEI LIMITI MASSIMI CONSENTITI DALLA LEGGE, NON SAREMO RESPONSABILI PER DANNI DIRETTI O
+      INDIRETTI DERIVANTI DALL'USO DEL SITO. LA NOSTRA RESPONSABILITÀ COMPLESSIVA NON SUPERERÀ IL
+      MAGGIORE TRA 1,00 USD E L'EVENTUALE IMPORTO DA TE CORRISPOSTO DIRETTAMENTE NEI 12 MESI
+      PRECEDENTI.
+    </p>
+
+    <h2>21. Manleva</h2>
+    <p>
+      Accetti di manlevarci e tenerci indenni da reclami o danni connessi al tuo uso del Sito,
+      ai tuoi contenuti inviati, alla violazione della presente Politica o di norme applicabili.
+    </p>
+
+    <h2>22. Risoluzione</h2>
+    <p>
+      Possiamo sospendere o terminare l'accesso al Sito in qualsiasi momento. Le clausole che per
+      loro natura devono sopravvivere continueranno ad avere efficacia.
+    </p>
+
+    <h2>23. Legge applicabile e foro competente</h2>
+    <p>
+      Questa Politica è regolata dalle leggi dello Stato del Maryland e degli Stati Uniti. Ogni
+      controversia sarà devoluta in via esclusiva ai tribunali statali o federali del Maryland.
+    </p>
+
+    <h2>24. Rinuncia alle azioni collettive e termini</h2>
+    <p>
+      NEI LIMITI CONSENTITI DALLA LEGGE, QUALSIASI PRETESA DEVE ESSERE PROPOSTA A TITOLO
+      INDIVIDUALE E ENTRO UN (1) ANNO DAL MOMENTO IN CUI È SORTA.
+    </p>
+
+    <h2>25. Separabilità, rinuncia, accordo integrale, cessione</h2>
+    <p>
+      Se una clausola è invalida o inapplicabile, le restanti restano efficaci. Qualsiasi rinuncia
+      è valida solo se scritta e firmata. Questa Politica costituisce l'intero accordo tra te e il
+      Titolare. Possiamo cedere i nostri diritti; tu non puoi cedere i tuoi senza consenso scritto.
+    </p>
+
+    <h2>26. Contatti</h2>
+    <p>
+      Per domande su questa Politica, contatta
+      <a href="mailto:me@bennyhartnett.com">me@bennyhartnett.com</a>.
+    </p>
+
+    <p>
+      Questo documento è pubblicato sul Sito come Informativa sulla privacy e termini di utilizzo di
+      riferimento.
+    </p>
+  </section>
+
+
   <a href="/">Back to Home</a>
   </article>
 </main>
@@ -864,7 +1310,8 @@
   const initialLanguage = queryLanguage || storedLanguage || 'en';
 
   function setLanguage(language) {
-    const nextLanguage = language === 'es' ? 'es' : 'en';
+    const availableLanguages = ['en', 'es', 'fr', 'it'];
+    const nextLanguage = availableLanguages.includes(language) ? language : 'en';
     languageSelector.value = nextLanguage;
     localStorage.setItem('privacy-language', nextLanguage);
 

--- a/sw.js
+++ b/sw.js
@@ -1,6 +1,6 @@
 // Service Worker for SWU Calculator PWA
 // Version must be updated when deploying new code to bust cache
-const CACHE_VERSION = 'v142';
+const CACHE_VERSION = 'v144';
 const CACHE_NAME = `swu-calculator-${CACHE_VERSION}`;
 
 // Files to cache for offline use


### PR DESCRIPTION
### Motivation
- Provide French and Italian versions of the Privacy Policy so visitors can read the site policy in their language and persist their preference.
- Ensure clients receive updated offline assets after content changes by bumping the service worker cache version.

### Description
- Added `Français` and `Italiano` options to the language `<select>` and inserted full `<section data-language-content="fr">` and `<section data-language-content="it">` translations into `pages/privacy.html`.
- Updated the language selection script to recognize `['en', 'es', 'fr', 'it']`, persist the selection in `localStorage`, and respect the `?lang=` query parameter via `setLanguage`.
- Bumped the service worker `CACHE_VERSION` from `v142` to `v144` in `sw.js` to force clients to refresh cached assets.

### Testing
- Ran the site build with `npm run build` and observed no build errors.
- Performed a smoke test by loading `pages/privacy.html` and switching languages with the selector and with `?lang=fr`/`?lang=it`, confirming the corresponding sections become active.
- Registered the updated service worker locally and verified the new `CACHE_NAME` is used and there were no SW registration errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e86f6f5dec832da79b0f6cd37c3ac8)