### PR TITLE
Use `sent.` subdomain for contact redirects; update assets, metadata, SW and worker behavior

### DIFF
--- a/docs/subdomain-routing.md
+++ b/docs/subdomain-routing.md
@@ -164,9 +164,6 @@ subdomain request (e.g., contact.bennyhartnett.com/some/path)
   │           (e.g., contact.bennyhartnett.com/js/app.js
   │            → fetches bennyhartnett.com/js/app.js)
   │
-  ├─ Is subdomain = "thank-you"?
-  │  └─ YES → 301 redirect to sent.bennyhartnett.com
-  │
   ├─ Is subdomain = "nuclear" or "centrus"?
   │  └─ YES → Fetch nuclear.html from origin (standalone page, not SPA)
   │
@@ -568,7 +565,7 @@ The service worker caches aggressively. If you update files but don't increment 
 Since `contact.bennyhartnett.com` and `bennyhartnett.com` are different origins, `fetch()` calls from the SPA to load page fragments are technically cross-origin. The worker handles this by proxying the requests, making them appear same-origin to the browser (the response comes from `contact.bennyhartnett.com`).
 
 ### Subdomain Aliases
-The worker supports aliases: `centrus.bennyhartnett.com` → serves `nuclear.html` (same as `nuclear.bennyhartnett.com`). And `thank-you.bennyhartnett.com` → 301 redirects to `sent.bennyhartnett.com`.
+The worker supports aliases: `centrus.bennyhartnett.com` → serves `nuclear.html` (same as `nuclear.bennyhartnett.com`).
 
 ### Static Asset Regex Includes .html
 The static asset detection intentionally includes `.html` files. This is critical: the SPA fetches `pages/contact.html` via AJAX from within `contact.bennyhartnett.com`. Without `.html` in the static asset list, this fetch would return `index.html` again instead of the fragment, causing an infinite loading issue.

--- a/js/meta-manager.js
+++ b/js/meta-manager.js
@@ -39,11 +39,11 @@ const META_MAP = {
     ogImage: BASE_OG_IMAGE,
     ogImageAlt: 'Contact Benny Hartnett'
   },
-  'pages/thank-you.html': {
-    title: 'Thank You - Benny Hartnett',
-    desc: 'Thank you for your message.',
+  'pages/sent.html': {
+    title: 'Message Sent - Benny Hartnett',
+    desc: 'Your message has been sent successfully.',
     ogImage: BASE_OG_IMAGE,
-    ogImageAlt: 'Thank You - Benny Hartnett'
+    ogImageAlt: 'Message Sent - Benny Hartnett'
   },
   'pages/projects.html': {
     title: 'Projects - Benny Hartnett',

--- a/pages/contact.html
+++ b/pages/contact.html
@@ -223,7 +223,7 @@
 <div class="contact-container">
   <form class="contact-form" action="https://formly.email/submit" method="POST">
     <input type="hidden" name="access_key" value="385292dab4c64964b1cd656cbc86fba1">
-    <input type="hidden" name="redirect" value="https://bennyhartnett.com/thank-you">
+    <input type="hidden" name="redirect" value="https://sent.bennyhartnett.com/">
     <h1>Get in Touch</h1>
     <p>Have a question or want to work together? Send me a message.</p>
 

--- a/pages/sent.html
+++ b/pages/sent.html
@@ -5,7 +5,7 @@
     color: white;
     margin: 0;
   }
-  .thank-you-container {
+  .sent-container {
     min-height: calc(100vh - 56px - 2rem);
     min-height: calc(100svh - 56px - 2rem); /* Mobile-friendly viewport height */
     display: flex;
@@ -15,14 +15,14 @@
     padding: 1rem;
     text-align: center;
   }
-  .thank-you-content {
+  .sent-content {
     max-width: 500px;
   }
-  .thank-you-content h1 {
+  .sent-content h1 {
     font-size: 2.5rem;
     margin-bottom: 1rem;
   }
-  .thank-you-content p {
+  .sent-content p {
     color: rgba(255, 255, 255, 0.7);
     font-size: 1.1rem;
     line-height: 1.6;
@@ -84,17 +84,17 @@
   }
 
   @media (max-width: 600px) {
-    .thank-you-content h1 {
+    .sent-content h1 {
       font-size: 1.75rem;
     }
-    .thank-you-content p {
+    .sent-content p {
       font-size: 1rem;
     }
   }
 </style>
-<div class="thank-you-container">
-  <div class="thank-you-content">
-    <h1>Thank You!</h1>
+<div class="sent-container">
+  <div class="sent-content">
+    <h1>Message Sent</h1>
     <p>Your message has been sent successfully. I'll get back to you as soon as possible.</p>
     <p class="countdown">Redirecting to home in <span id="countdown">5</span> seconds...</p>
     <a href="https://bennyhartnett.com" class="home-btn">Return Home</a>

--- a/sw.js
+++ b/sw.js
@@ -1,6 +1,6 @@
 // Service Worker for SWU Calculator PWA
 // Version must be updated when deploying new code to bust cache
-const CACHE_VERSION = 'v144';
+const CACHE_VERSION = 'v145';
 const CACHE_NAME = `swu-calculator-${CACHE_VERSION}`;
 
 // Files to cache for offline use

--- a/workers/router.js
+++ b/workers/router.js
@@ -107,11 +107,6 @@ async function handleSubdomain(request, url, hostname, rootDomain) {
     });
   }
 
-  // Redirect thank-you subdomain to sent subdomain (at root)
-  if (subdomain === 'thank-you') {
-    return Response.redirect(`https://sent.${rootDomain}/`, 301);
-  }
-
   // Redirect ASCII aliases to their canonical IDN (punycode) subdomains
   if (ASCII_TO_IDN[subdomain]) {
     return Response.redirect(`https://${ASCII_TO_IDN[subdomain]}.${rootDomain}/`, 301);

--- a/workers/router.test.js
+++ b/workers/router.test.js
@@ -118,14 +118,17 @@ describe('workers/router', () => {
     expect(calledUrls).toContain('https://bennyhartnett.com/nuclear.html');
   });
 
-  it('redirects thank-you subdomain to sent subdomain', async () => {
-    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(makeResponse());
+  it('treats sent subdomain like a normal SPA subdomain', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(makeResponse('index ok'));
 
-    const response = await worker.fetch(new Request('https://thank-you.bennyhartnett.com/'), {}, {});
+    const response = await worker.fetch(new Request('https://sent.bennyhartnett.com/'), {}, {});
 
-    expect(response.status).toBe(301);
-    expect(response.headers.get('location')).toBe('https://sent.bennyhartnett.com/');
-    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe('index ok');
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchSpy.mock.calls[0];
+    expect(String(url)).toBe('https://bennyhartnett.com/');
+    expect(init.headers.get('X-CF-Worker-Internal')).toBe('1');
   });
 
   it('redirects ascii resume subdomain to canonical punycode idn', async () => {


### PR DESCRIPTION
### Motivation
- Change the contact form redirect to use a dedicated `sent.bennyhartnett.com` SPA subdomain and stop treating a `thank-you` subdomain as a special redirect target.
- Ensure SPA page fragments, metadata, and worker routing remain consistent with the new `sent` page and subdomain.

### Description
- Updated the contact form `redirect` in `pages/contact.html` to `https://sent.bennyhartnett.com/`.
- Added/renamed the success page to `pages/sent.html` and adjusted its markup and copy to "Message Sent" and a countdown redirect back to the main site.
- Updated `js/meta-manager.js` to use the `pages/sent.html` key and revised title/description/OG alt text accordingly.
- Modified the Cloudflare Worker router (`workers/router.js`) to remove the special-case redirect from `thank-you` to `sent` and treat `sent` as a normal SPA subdomain (static assets proxied from the main domain and index served for SPA pages); kept `nuclear`/`centrus` and alias handling intact.
- Bumped the service worker cache version in `sw.js` from `v144` to `v145`.
- Updated documentation `docs/subdomain-routing.md` to remove the `thank-you` redirect mention and reflect the `sent` behavior.
- Adjusted unit tests in `workers/router.test.js` to expect `sent.bennyhartnett.com` to be served as a normal SPA subdomain and verified the worker fetches the main `https://bennyhartnett.com/` index with the internal header.

### Testing
- Ran unit tests around the router (`workers/router.test.js`) with `vitest` and the updated test asserting that `https://sent.bennyhartnett.com/` returns the proxied index passed; tests passed.
- Ran the existing asset-fetch unit test that verifies static assets are fetched from the main domain with the `X-CF-Worker-Internal` header; the test passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8f40f924c832db8f8636849a7178b)