### PR TITLE
Make resume PDF surfaces fully transparent

### DIFF
--- a/pages/resume.html
+++ b/pages/resume.html
@@ -13,6 +13,7 @@
     min-height: calc(100vh - 56px);
     min-height: calc(100svh - 56px); /* Mobile-friendly viewport height */
     padding: 20px 0;
+    background: transparent;
   }
   a.download-btn {
     display: inline-flex;
@@ -101,14 +102,12 @@
   }
   /* Dark mode styles for PDF */
   .pdf-pages.dark-mode {
-    background: rgba(255, 255, 255, 0.04);
-    backdrop-filter: blur(12px);
-    -webkit-backdrop-filter: blur(12px);
-    border: 1px solid rgba(255, 255, 255, 0.15);
-    border-radius: 12px;
-    box-shadow:
-      0 8px 32px rgba(0, 0, 0, 0.3),
-      inset 0 1px 0 rgba(255, 255, 255, 0.1);
+    background: transparent;
+    backdrop-filter: none;
+    -webkit-backdrop-filter: none;
+    border: none;
+    border-radius: 0;
+    box-shadow: none;
   }
   .pdf-pages.dark-mode .pdf-page canvas {
     filter: invert(1) hue-rotate(180deg);
@@ -137,11 +136,11 @@
     }
   }
   .pdf-pages {
-    box-shadow: 0 2px 10px rgba(0,0,0,0.3);
-    background: rgba(255, 255, 255, 0.08);
-    backdrop-filter: blur(12px);
-    -webkit-backdrop-filter: blur(12px);
-    border-radius: 6px;
+    box-shadow: none;
+    background: transparent;
+    backdrop-filter: none;
+    -webkit-backdrop-filter: none;
+    border-radius: 0;
     overflow: clip;
   }
   .pdf-page {


### PR DESCRIPTION
### Motivation
- The resume PDF view used a frosted/white-card visual (tinted background, blur, border, shadow, rounded corners) which obstructed the site background and prevented true transparency.
- Dark-mode variant reintroduced glassmorphism, so it needed the same transparency treatment to remain visually consistent.

### Description
- Set `.pdf-container` to `background: transparent;` to prevent the parent wrapper from adding an opaque/frosted layer.
- Updated `.pdf-pages` to remove the glassmorphic styling by applying `background: transparent;`, `backdrop-filter: none;`, `-webkit-backdrop-filter: none;`, `box-shadow: none;`, and `border-radius: 0;`.
- Applied the same removals to `.pdf-pages.dark-mode` by replacing the translucent background, blur filters, border, and shadow with transparent/none values.
- Left page rendering logic (canvas inversion for dark mode) intact while removing the surrounding card-like visuals.

### Testing
- Ran the test suite with `npm test` and all automated tests passed (Test Files: 6 passed, Tests: 98 passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8f948f7e4832db223149aa4101603)