### PR TITLE
Allow panoramic viewer to load uploaded photos as well as URLs

### DIFF
--- a/pages/panoramic.html
+++ b/pages/panoramic.html
@@ -68,6 +68,18 @@
     transform: translateY(-1px);
   }
 
+  .panoramic-upload-wrap {
+    position: relative;
+    overflow: hidden;
+  }
+
+  .panoramic-upload {
+    position: absolute;
+    inset: 0;
+    opacity: 0;
+    cursor: pointer;
+  }
+
   .panoramic-toggle {
     display: inline-flex;
     align-items: center;
@@ -115,7 +127,7 @@
 <div class="panoramic-page">
   <header class="panoramic-header">
     <h1>Panoramic Viewer</h1>
-    <p>Look around a 360° panoramic photo like Street View. Paste any equirectangular image URL to load your own scene.</p>
+    <p>Look around a 360° panoramic photo like Street View. Paste an equirectangular image URL or upload a panoramic photo from your device.</p>
   </header>
 
   <div class="panoramic-controls">
@@ -127,7 +139,11 @@
       placeholder="https://example.com/panorama.jpg"
       aria-label="Panoramic image URL"
     />
-    <button id="panoramic-load" class="panoramic-btn" type="button">Load photo</button>
+    <label class="panoramic-upload-wrap panoramic-btn" for="panoramic-upload">
+      <input id="panoramic-upload" class="panoramic-upload" type="file" accept="image/*" aria-label="Upload panoramic image" />
+      Upload photo
+    </label>
+    <button id="panoramic-load" class="panoramic-btn" type="button">Load URL</button>
     <button id="panoramic-reset" class="panoramic-btn" type="button">Reset view</button>
     <label class="panoramic-toggle" for="panoramic-loop">
       <input id="panoramic-loop" type="checkbox" checked />
@@ -151,11 +167,13 @@
     const viewerNode = scope.querySelector('#panoramic-viewer');
     const urlInput = scope.querySelector('#panoramic-url');
     const loadButton = scope.querySelector('#panoramic-load');
+    const uploadInput = scope.querySelector('#panoramic-upload');
     const resetButton = scope.querySelector('#panoramic-reset');
     const loopToggle = scope.querySelector('#panoramic-loop');
     const statusNode = scope.querySelector('#panoramic-status');
 
     let viewer;
+    let objectUrl;
 
     function setStatus(message, isError = false) {
       statusNode.textContent = message;
@@ -171,9 +189,17 @@
       }
     }
 
-    function createViewer(url) {
+    function revokeObjectUrl() {
+      if (!objectUrl) {
+        return;
+      }
+      URL.revokeObjectURL(objectUrl);
+      objectUrl = null;
+    }
+
+    function createViewer(url, sourceLabel = 'URL') {
       if (!url) {
-        setStatus('Enter a panoramic image URL first.', true);
+        setStatus('Enter a panoramic image URL or upload a photo first.', true);
         return;
       }
 
@@ -189,25 +215,37 @@
       });
 
       viewer.on('load', () => {
-        setStatus('Panorama loaded. Drag to look around.');
+        setStatus(`Panorama loaded from ${sourceLabel}. Drag to look around.`);
         applyLoopSetting();
       });
 
       viewer.on('error', (error) => {
-        const message = error && error.message ? error.message : 'Unable to load that image URL.';
+        const message = error && error.message ? error.message : `Unable to load panoramic image from ${sourceLabel}.`;
         setStatus(message, true);
       });
     }
 
     loadButton.addEventListener('click', () => {
-      createViewer(urlInput.value.trim());
+      revokeObjectUrl();
+      createViewer(urlInput.value.trim(), 'URL');
     });
 
     urlInput.addEventListener('keydown', (event) => {
       if (event.key === 'Enter') {
         event.preventDefault();
-        createViewer(urlInput.value.trim());
+        revokeObjectUrl();
+        createViewer(urlInput.value.trim(), 'URL');
       }
+    });
+
+    uploadInput.addEventListener('change', () => {
+      const file = uploadInput.files && uploadInput.files[0];
+      if (!file) {
+        return;
+      }
+      revokeObjectUrl();
+      objectUrl = URL.createObjectURL(file);
+      createViewer(objectUrl, `upload (${file.name})`);
     });
 
     resetButton.addEventListener('click', () => {
@@ -224,6 +262,7 @@
       setStatus(loopToggle.checked ? '360 loop enabled.' : '360 loop disabled.');
     });
 
-    createViewer(urlInput.value.trim());
+    createViewer(urlInput.value.trim(), 'URL');
+    window.addEventListener('beforeunload', revokeObjectUrl);
   })();
 </script>

--- a/sw.js
+++ b/sw.js
@@ -1,6 +1,6 @@
 // Service Worker for SWU Calculator PWA
 // Version must be updated when deploying new code to bust cache
-const CACHE_VERSION = 'v147';
+const CACHE_VERSION = 'v148';
 const CACHE_NAME = `swu-calculator-${CACHE_VERSION}`;
 
 // Files to cache for offline use


### PR DESCRIPTION
### Motivation
- Provide users the ability to open a local panoramic photo in the existing Panoramic Viewer in addition to pasting an image URL.
- Ensure uploaded files do not leak memory and that status messages reflect the source of the image (URL vs upload).
- Make the updated page available to clients by bumping the service worker cache version.

### Description
- Added a file input wrapped in a styled label to `pages/panoramic.html` so users can select a local image (`#panoramic-upload`), and relabeled the existing load action to `Load URL`.
- Implemented handling for uploads by creating an object URL with `URL.createObjectURL` and revoking it with `URL.revokeObjectURL` to avoid leaks, and threaded a `sourceLabel` through `createViewer` so status/error text indicates the image source.
- Kept the existing URL flow intact (button and Enter key) and ensured any prior object URL is revoked before loading a new source.
- Bumped the service worker cache version in `sw.js` (`CACHE_VERSION` updated to `v148`) so the modified page is cached on deploy.

### Testing
- Ran `npm test` which executed the test suite and succeeded with all tests passing (`6` test files, `98` tests passed).
- No browser automation was run in this environment; feature tested via local code inspection and unit tests only.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e97f985520832da3884cda74320a6b)